### PR TITLE
Added preserve_tree option to the config file.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog of checkoutmanager
 2.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Added a preserve_tree option to config files to allow structured
+  checkouts mirroring the repository tree.
+  [chintal]
 
 
 2.2 (2015-08-24)

--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,19 @@ takes the last part.  Some exceptions, most for subversion:
 
 - Git checkouts lose the ".git" at the end of the url.
 
+Optionally, a "preserve_tree" option may be set for each group in the
+configuration. The "preserve_tree" option, if used, should contain one or more
+base checkout urls (one per line). If the "preserve_tree" option is set, then
+the default output directory is chosen using the following rules:
+
+- If the checkout url starts with one of the strings specified in the
+  "preserve_tree" configuration option, then this string is stripped and the
+  rest of the checkout url is used as is, thereby preserving any folder
+  structure that may exist under the base checkout url.
+
+- If a matching server root is not found, the standard rules which would have
+  been used if "preserve_tree" was left unset will be used instead.
+
 If you want something else, just specify a directory name (separated by a
 space) in the configuration file.
 

--- a/checkoutmanager/tests/config.txt
+++ b/checkoutmanager/tests/config.txt
@@ -96,6 +96,13 @@ Git has some special cases too:
     ... 'git@git.example.org:projectname', 'projectname')
     True
 
+Preserved tree type checkouts:
+
+    >>> config.extract_spec('svn://some.svn.server/folder1/folder1a/repo1',
+    ... preserve_tree=["svn://some.svn.server/"]) == ('svn://some.svn.server/folder1/folder1a/repo1',
+    ... 'folder1/folder1a/repo1')
+    True
+
 Find directories
 ----------------
 


### PR DESCRIPTION
This adds the following options to the config file, along with the ability to optionally change the behaviour of the default output directory. 

- preserve_tree
- server_roots

Usage example : 

    [some-name]
    vcs = svn
    basedir = /some/directory
    preserve_tree = True
    server_roots = 
            svn://some.svn.server/
    checkouts =
            svn://some.svn.server/folder1/folder1a/repo1
            svn://some.svn.server/folder1/folder1b/repo1
            svn://some.svn.server/folder2/folder2a/repo2
            svn://some.svn.server/folder3/folder3c/repo5

Which creates the following tree : 

    /some/directory/folder1/folder1a/repo1
    /some/directory/folder1/folder1b/repo1
    /some/directory/folder2/folder2a/repo2
    /some/directory/folder3/folder3c/repo5
