### PR TITLE
Basic hooks

### DIFF
--- a/checkoutmanager/config.py
+++ b/checkoutmanager/config.py
@@ -116,6 +116,12 @@ class Config(object):
                 result.append(dirinfoclass(directory, url))
         return sorted(result)
 
+    def directory_from_url(self, url):
+        return [x for x in self.directories() if x.url == url][0]
+
+    def directory_from_path(self, abspath):
+        return [x for x in self.directories() if x.directory == abspath][0]
+
     def report_missing(self, group=None):
         if group:
             sections = [group]

--- a/checkoutmanager/config.py
+++ b/checkoutmanager/config.py
@@ -117,10 +117,18 @@ class Config(object):
         return sorted(result)
 
     def directory_from_url(self, url):
-        return [x for x in self.directories() if x.url == url][0]
+        for dir_info in self.directories():
+            if dir_info.url == url:
+                return dir_info
 
-    def directory_from_path(self, abspath):
-        return [x for x in self.directories() if x.directory == abspath][0]
+    def directory_from_path(self, abspath, allow_ancestors=True):
+        for dir_info in self.directories():
+            if dir_info.directory == abspath:
+                return dir_info
+        if allow_ancestors:
+            parent = os.path.split(abspath)[0]
+            if parent:
+                return self.directory_from_path(parent)
 
     def report_missing(self, group=None):
         if group:

--- a/checkoutmanager/runner.py
+++ b/checkoutmanager/runner.py
@@ -82,6 +82,25 @@ def execute_action(dirinfo, custom_actions, action):
         return e
 
 
+def run_one(action, directory=None, url=None, conf=None):
+    custom_actions = get_custom_actions()
+    if not conf:
+        conf = config.Config(os.path.expanduser(CONFIGFILE_NAME))
+    from .dirinfo import DirInfo
+    if directory:
+        if isinstance(directory, str):
+            directory = conf.directory_from_path(directory)
+        elif not isinstance(directory, DirInfo):
+            raise TypeError("directory of unrecognized type. Should be path (string) or"
+                            "DirInfo instance.")
+    elif url:
+        directory = conf.directory_from_url(url)
+    executor = get_executor(single=True)
+    executor.execute(execute_action, (directory, custom_actions, action))
+    executor.wait_for_results()
+    return executor
+
+
 def run(action, group=None, conf=None, single=False):
     custom_actions = get_custom_actions()
     if not conf:

--- a/checkoutmanager/tests/config.txt
+++ b/checkoutmanager/tests/config.txt
@@ -158,5 +158,7 @@ When used as a python module, DirInfo objects can be obtained programmatically:
 
     >>> conf.directory_from_url('svn://svn/blablabla/trunk')
     <DirInfo (svn) for HOMEDIR/svn/recipes/blablabla>
-    >>> conf.directory_from_path('HOMEDIR/svn/recipes/blablabla')
+    >>> conf.directory_from_path('%s/svn/recipes/blablabla' % homedir)
+    <DirInfo (svn) for HOMEDIR/svn/recipes/blablabla>
+    >>> conf.directory_from_path('%s/svn/recipes/blablabla/somefolder' % homedir)
     <DirInfo (svn) for HOMEDIR/svn/recipes/blablabla>

--- a/checkoutmanager/tests/config.txt
+++ b/checkoutmanager/tests/config.txt
@@ -153,3 +153,10 @@ We can ignore certain directories and support globbing to do so:
     >>> conf.report_missing(group='recipes') # doctest: +ELLIPSIS
     Unconfigured items in HOMEDIR/svn/recipes [svn]:
         HOMEDIR/svn/recipes/missing
+
+When used as a python module, DirInfo objects can be obtained programmatically:
+
+    >>> conf.directory_from_url('svn://svn/blablabla/trunk')
+    <DirInfo (svn) for HOMEDIR/svn/recipes/blablabla>
+    >>> conf.directory_from_path('HOMEDIR/svn/recipes/blablabla')
+    <DirInfo (svn) for HOMEDIR/svn/recipes/blablabla>


### PR DESCRIPTION
Added hooks to obtain dirinfo from config given a url or directory path, and run_one() to execute actions against a single DirInfo.

For some reason the test for directory_from_path doesn't run. I can't seem to figure out why. It works for me though : 

    >>> c.directory_from_path('/home/chintal/quazar/svn/ARM-Prog')
    <DirInfo (svn) for /home/chintal/quazar/svn/ARM-Prog>
