### PR TITLE
New actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,15 @@ co
 missing
   Print directories that are missing from the config file
 
+out
+  Show changesets you haven't pushed to the server yet
+
+in
+  Show incoming changesets that would be pulled in with 'up'. For some
+  version control systems, this depends on the English output of the
+  respective commands and is therefore inherently fragile.
+
+
 
 Hidden commands
 ---------------

--- a/checkoutmanager/runner.py
+++ b/checkoutmanager/runner.py
@@ -13,7 +13,7 @@ from checkoutmanager import utils
 from checkoutmanager.executors import get_executor
 
 
-ACTIONS = ['exists', 'up', 'st', 'co', 'missing', 'out']
+ACTIONS = ['exists', 'up', 'st', 'co', 'missing', 'out', 'cu', 'rev']
 CONFIGFILE_NAME = '~/.checkoutmanager.cfg'
 ACTION_EXPLANATION = {
     'exists': "Print whether checkouts are present or missing",
@@ -22,6 +22,8 @@ ACTION_EXPLANATION = {
     'co': "Grab missing checkouts from the server",
     'missing': "Print directories that are missing from the config file",
     'out': "Show changesets you haven't pushed to the server yet",
+    'cu': "Check for updates that will be pulled in with 'up'",
+    'rev': "Get the current revision information",
     }
 
 

--- a/checkoutmanager/runner.py
+++ b/checkoutmanager/runner.py
@@ -13,7 +13,7 @@ from checkoutmanager import utils
 from checkoutmanager.executors import get_executor
 
 
-ACTIONS = ['exists', 'up', 'st', 'co', 'missing', 'out', 'cu', 'rev']
+ACTIONS = ['exists', 'up', 'st', 'co', 'missing', 'out', 'in', 'rev']
 CONFIGFILE_NAME = '~/.checkoutmanager.cfg'
 ACTION_EXPLANATION = {
     'exists': "Print whether checkouts are present or missing",
@@ -22,8 +22,8 @@ ACTION_EXPLANATION = {
     'co': "Grab missing checkouts from the server",
     'missing': "Print directories that are missing from the config file",
     'out': "Show changesets you haven't pushed to the server yet",
-    'cu': "Check for updates that will be pulled in with 'up'",
-    'rev': "Get the current revision information",
+    'in': "Show incoming changesets that would be pulled in with 'up'",
+    'rev': "Print the current revision number",
     }
 
 


### PR DESCRIPTION
Added actions ``in`` and ``rev``. 

``in``
-------
(previously ``cu``)

Check for incoming changes before applying them. 

Typical usage is to determine which repositories have incoming updates, and to use that information to prevent expected problems by cleaning up necessary trees when ``up`` is run, or by not running ``up`` at that point if it's likely to cause merge conflicts or the like. ``in`` should not change the local filesystem in any way (working copy or repository), given that we don't make any assumptions about the workflow the user wants to use.

``rev``
--------

Print the current revision of the working tree. There isn't much use for it when run as a script, but there are use cases for being able to obtain this revision information when used as a module. My immediate use case is to include the revision information of semi-automated test definitions when generating test reports from semi-automated or automated tests. I'm using pysvn to get the revision information for the moment, which works fine, but locks me in to svn.


Implementations notes
-----------------------------

Both of these work actions work fine for SVN, and if there are problems or corner cases I'll see them soon enough.

bzr, git, and hg implementations have only been tested on simple repositories with a simple upstream and clean working trees. I think they should still work, but some care may be called for before making use of these actions in production for those version systems. 