### PR TITLE
Initial binary-in-loop tests including vcs binaries

### DIFF
--- a/checkoutmanager/tests/dirinfo_bzr.rst
+++ b/checkoutmanager/tests/dirinfo_bzr.rst
@@ -1,0 +1,109 @@
+
+.. :doctest:
+
+    >>> import subprocess
+    >>> import os
+    >>> from checkoutmanager.dirinfo import GitDirInfo
+    >>> orig_cwd = os.getcwd()
+
+The tests will all run inside the homedir which the testsetup made for us:
+
+    >>> print(homedir)
+    HOMEDIR
+
+Create the config file:
+
+    >>> vcstest_config_path = os.path.join(homedir, 'vcstestconfig.cfg')
+    >>> import pkg_resources
+    >>> vcstest_config_tpath = pkg_resources.resource_filename(
+    ...     'checkoutmanager.tests', 'vcstestconfig.cfg.templ')
+    >>> with open(vcstest_config_tpath, 'r') as f:
+    ...     vcstest_config_tstr = str(f.read())
+    >>> import jinja2
+    >>> vcstest_config_t = jinja2.Template(vcstest_config_tstr)
+    >>> with open(vcstest_config_path, 'w') as f:
+    ...     lc = f.write(vcstest_config_t.render(homedir=homedir))
+    >>> from checkoutmanager import config
+    >>> conf = config.Config(vcstest_config_path)
+
+Make yourself a folder inside which all bzr tests will run:
+
+    >>> bzr_repos_root = os.path.join(homedir, 'repos_bzr')
+    >>> os.makedirs(bzr_repos_root)
+    >>> print(bzr_repos_root)
+    HOMEDIR/repos_bzr
+
+Initialize bzr:
+
+    >>> cmd = ['bzr', 'whoami', '\"Some Tester <someone@test.test>\"']
+    >>> subprocess.call(cmd)
+    0
+
+
+Create a bzr repository:
+
+    >>> bzr_base = os.path.join(bzr_repos_root, 'base')
+    >>> os.makedirs(bzr_base)
+    >>> cmd = ['bzr', 'init', bzr_base]
+    >>> subprocess.call(cmd)
+    0
+
+Create a file inside the base working copy and commit:
+
+    >>> os.chdir(bzr_base)
+    >>> with open(os.path.join(bzr_base, 'test_file'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> cmd = ['bzr', 'add', 'test_file']
+    >>> subprocess.call(cmd)
+    0
+    >>> cmd = ['bzr', 'commit', '-m', '\"one commit\"']
+    >>> subprocess.call(cmd)
+    0
+
+Create the other working copies using checkoutmanager:
+
+    >>> bzr_follower = os.path.join(bzr_repos_root, 'follower')
+    >>> bzr_leader = os.path.join(bzr_repos_root, 'leader')
+    >>> from checkoutmanager import runner
+    >>> executor = runner.run_one('co', directory=bzr_follower, conf=conf)
+    >>> # TODO Test Executor for CO Action
+    >>> assert executor.errors == []
+    >>> executor = runner.run_one('co', directory=bzr_leader, conf=conf)
+    >>> assert executor.errors == []
+
+Create commit on base to bring it ahead of the follower:
+
+    >>> os.chdir(bzr_base)
+    >>> with open(os.path.join(bzr_base, 'test_file_2'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> # TODO Run and Test for ST Action
+    >>> cmd = ['bzr', 'add', 'test_file_2']
+    >>> subprocess.call(cmd)
+    >>> cmd = ['bzr', 'commit', '-m', '\"second commit\"']
+    >>> subprocess.call(cmd)
+
+Update leader to bring it alongside base:
+
+    >>> from checkoutmanager import runner
+    >>> executor = runner.run_one('up', directory=bzr_leader, conf=conf)
+    >>> # TODO Test Executor for UP Action
+
+Create commit on leader to bring it ahead of the base:
+
+    >>> os.chdir(bzr_leader)
+    >>> with open(os.path.join(bzr_leader, 'test_file_3'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> # TODO Run and Test for ST Action
+    >>> cmd = ['bzr', 'add', 'test_file_3']
+    >>> subprocess.call(cmd)
+    >>> cmd = ['bzr', 'commit', '-m', '\"third commit\"']
+    >>> subprocess.call(cmd)
+
+The follower - leader - base hierarchy is now setup.
+
+Teardown:
+
+    >>> os.chdir(orig_cwd)
+
+
+

--- a/checkoutmanager/tests/dirinfo_git.rst
+++ b/checkoutmanager/tests/dirinfo_git.rst
@@ -103,6 +103,41 @@ Create commit on leader to bring it ahead of the base:
 
 The follower - leader - base hierarchy is now setup.
 
+Tests for the 'rev' dirinfo action:
+
+    >>> from checkoutmanager import reports
+    >>> executor = runner.run_one('rev', directory=git_base, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> assert isinstance(executor.reports[0].revision, str)
+    >>> executor = runner.run_one('rev', directory=git_leader, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> assert isinstance(executor.reports[0].revision, str)
+    >>> executor = runner.run_one('rev', directory=git_follower, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> assert isinstance(executor.reports[0].revision, str)
+    >>> # TODO handle error conditons
+
+Tests for the 'in' dirinfo action:
+
+    >>> executor = runner.run_one('in', directory=git_follower, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.errors) == 0
+    >>> if len(executor.parse_errors):
+    ...     for error in executor.parse_errors:
+    ...         error.print_msg()
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportIncoming)
+    >>> assert isinstance(executor.reports[0].local_head, str)
+    >>> assert isinstance(executor.reports[0].remote_head, str)
+    >>> assert len(executor.reports[0].changesets) == 0
+
 Teardown:
 
     >>> os.chdir(orig_cwd)

--- a/checkoutmanager/tests/dirinfo_git.rst
+++ b/checkoutmanager/tests/dirinfo_git.rst
@@ -1,0 +1,111 @@
+
+.. :doctest:
+
+    >>> import subprocess
+    >>> import os
+    >>> from checkoutmanager.dirinfo import GitDirInfo
+    >>> orig_cwd = os.getcwd()
+
+The tests will all run inside the homedir which the testsetup made for us:
+
+    >>> print(homedir)
+    HOMEDIR
+
+Create the config file:
+
+    >>> vcstest_config_path = os.path.join(homedir, 'vcstestconfig.cfg')
+    >>> import pkg_resources
+    >>> vcstest_config_tpath = pkg_resources.resource_filename(
+    ...     'checkoutmanager.tests', 'vcstestconfig.cfg.templ')
+    >>> with open(vcstest_config_tpath, 'r') as f:
+    ...     vcstest_config_tstr = str(f.read())
+    >>> import jinja2
+    >>> vcstest_config_t = jinja2.Template(vcstest_config_tstr)
+    >>> with open(vcstest_config_path, 'w') as f:
+    ...     lc = f.write(vcstest_config_t.render(homedir=homedir))
+    >>> from checkoutmanager import config
+    >>> conf = config.Config(vcstest_config_path)
+
+Make yourself a folder inside which all git tests will run:
+
+    >>> git_repos_root = os.path.join(homedir, 'repos_git')
+    >>> os.makedirs(git_repos_root)
+    >>> print(git_repos_root)
+    HOMEDIR/repos_git
+
+Initialize git:
+
+    >>> cmd = ['git', 'config', '--global', 'user.email', '\"someone@test.test\"']
+    >>> subprocess.call(cmd)
+    0
+    >>> cmd = ['git', 'config', '--global', 'user.name', '\"Some Tester\"']
+    >>> subprocess.call(cmd)
+    0
+
+Create a git repository:
+
+    >>> git_base = os.path.join(git_repos_root, 'base')
+    >>> os.makedirs(git_base)
+    >>> cmd = ['git', 'init', git_base]
+    >>> subprocess.call(cmd)
+    0
+
+Create a file inside the base working copy and commit:
+
+    >>> os.chdir(git_base)
+    >>> with open(os.path.join(git_base, 'test_file'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> cmd = ['git', 'add', 'test_file']
+    >>> subprocess.call(cmd)
+    0
+    >>> cmd = ['git', 'commit', '-m', '\"one commit\"']
+    >>> subprocess.call(cmd)
+    0
+
+Create the other working copies using checkoutmanager:
+
+    >>> git_follower = os.path.join(git_repos_root, 'follower')
+    >>> git_leader = os.path.join(git_repos_root, 'leader')
+    >>> from checkoutmanager import runner
+    >>> executor = runner.run_one('co', directory=git_follower, conf=conf)
+    >>> # TODO Test Executor for CO Action
+    >>> assert executor.errors == []
+    >>> executor = runner.run_one('co', directory=git_leader, conf=conf)
+    >>> assert executor.errors == []
+
+Create commit on base to bring it ahead of the follower:
+
+    >>> os.chdir(git_base)
+    >>> with open(os.path.join(git_base, 'test_file_2'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> # TODO Run and Test for ST Action
+    >>> cmd = ['git', 'add', 'test_file_2']
+    >>> subprocess.call(cmd)
+    >>> cmd = ['git', 'commit', '-m', '\"second commit\"']
+    >>> subprocess.call(cmd)
+
+Update leader to bring it alongside base:
+
+    >>> from checkoutmanager import runner
+    >>> executor = runner.run_one('up', directory=git_leader, conf=conf)
+    >>> # TODO Test Executor for UP Action
+
+Create commit on leader to bring it ahead of the base:
+
+    >>> os.chdir(git_leader)
+    >>> with open(os.path.join(git_leader, 'test_file_3'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> # TODO Run and Test for ST Action
+    >>> cmd = ['git', 'add', 'test_file_3']
+    >>> subprocess.call(cmd)
+    >>> cmd = ['git', 'commit', '-m', '\"third commit\"']
+    >>> subprocess.call(cmd)
+
+The follower - leader - base hierarchy is now setup.
+
+Teardown:
+
+    >>> os.chdir(orig_cwd)
+
+
+

--- a/checkoutmanager/tests/dirinfo_hg.rst
+++ b/checkoutmanager/tests/dirinfo_hg.rst
@@ -1,0 +1,108 @@
+
+.. :doctest:
+
+    >>> import subprocess
+    >>> import os
+    >>> from checkoutmanager.dirinfo import GitDirInfo
+    >>> orig_cwd = os.getcwd()
+
+The tests will all run inside the homedir which the testsetup made for us:
+
+    >>> print(homedir)
+    HOMEDIR
+
+Create the config file:
+
+    >>> vcstest_config_path = os.path.join(homedir, 'vcstestconfig.cfg')
+    >>> import pkg_resources
+    >>> vcstest_config_tpath = pkg_resources.resource_filename(
+    ...     'checkoutmanager.tests', 'vcstestconfig.cfg.templ')
+    >>> with open(vcstest_config_tpath, 'r') as f:
+    ...     vcstest_config_tstr = str(f.read())
+    >>> import jinja2
+    >>> vcstest_config_t = jinja2.Template(vcstest_config_tstr)
+    >>> with open(vcstest_config_path, 'w') as f:
+    ...     lc = f.write(vcstest_config_t.render(homedir=homedir))
+    >>> from checkoutmanager import config
+    >>> conf = config.Config(vcstest_config_path)
+
+Make yourself a folder inside which all hg tests will run:
+
+    >>> hg_repos_root = os.path.join(homedir, 'repos_hg')
+    >>> os.makedirs(hg_repos_root)
+    >>> print(hg_repos_root)
+    HOMEDIR/repos_hg
+
+Initialize hg:
+
+    >>> with open(os.path.join(homedir, '.hgrc'), 'w') as f:
+    ...     f.writelines("[ui]\n")
+    ...     f.writelines("username = Some Tester <someone@test.test\n")
+
+Create a hg repository:
+
+    >>> hg_base = os.path.join(hg_repos_root, 'base')
+    >>> os.makedirs(hg_base)
+    >>> cmd = ['hg', 'init', hg_base]
+    >>> subprocess.call(cmd)
+    0
+
+Create a file inside the base working copy and commit:
+
+    >>> os.chdir(hg_base)
+    >>> with open(os.path.join(hg_base, 'test_file'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> cmd = ['hg', 'add', 'test_file']
+    >>> subprocess.call(cmd)
+    0
+    >>> cmd = ['hg', 'commit', '-m', '\"one commit\"']
+    >>> subprocess.call(cmd)
+    0
+
+Create the other working copies using checkoutmanager:
+
+    >>> hg_follower = os.path.join(hg_repos_root, 'follower')
+    >>> hg_leader = os.path.join(hg_repos_root, 'leader')
+    >>> from checkoutmanager import runner
+    >>> executor = runner.run_one('co', directory=hg_follower, conf=conf)
+    >>> # TODO Test Executor for CO Action
+    >>> assert executor.errors == []
+    >>> executor = runner.run_one('co', directory=hg_leader, conf=conf)
+    >>> assert executor.errors == []
+
+Create commit on base to bring it ahead of the follower:
+
+    >>> os.chdir(hg_base)
+    >>> with open(os.path.join(hg_base, 'test_file_2'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> # TODO Run and Test for ST Action
+    >>> cmd = ['hg', 'add', 'test_file_2']
+    >>> subprocess.call(cmd)
+    >>> cmd = ['hg', 'commit', '-m', '\"second commit\"']
+    >>> subprocess.call(cmd)
+
+Update leader to bring it alongside base:
+
+    >>> from checkoutmanager import runner
+    >>> executor = runner.run_one('up', directory=hg_leader, conf=conf)
+    >>> # TODO Test Executor for UP Action
+
+Create commit on leader to bring it ahead of the base:
+
+    >>> os.chdir(hg_leader)
+    >>> with open(os.path.join(hg_leader, 'test_file_3'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> # TODO Run and Test for ST Action
+    >>> cmd = ['hg', 'add', 'test_file_3']
+    >>> subprocess.call(cmd)
+    >>> cmd = ['hg', 'commit', '-m', '\"third commit\"']
+    >>> subprocess.call(cmd)
+
+The follower - leader - base hierarchy is now setup.
+
+Teardown:
+
+    >>> os.chdir(orig_cwd)
+
+
+

--- a/checkoutmanager/tests/dirinfo_hg.rst
+++ b/checkoutmanager/tests/dirinfo_hg.rst
@@ -100,6 +100,43 @@ Create commit on leader to bring it ahead of the base:
 
 The follower - leader - base hierarchy is now setup.
 
+Tests for the 'rev' dirinfo action:
+
+    >>> from checkoutmanager import reports
+    >>> executor = runner.run_one('rev', directory=hg_base, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> assert executor.reports[0].revision.startswith('1:')
+    >>> executor = runner.run_one('rev', directory=hg_leader, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> assert executor.reports[0].revision.startswith('2:')
+    >>> executor = runner.run_one('rev', directory=hg_follower, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> assert executor.reports[0].revision.startswith('0:')
+    >>> # TODO handle error conditons
+
+Tests for the 'in' dirinfo action:
+
+    >>> executor = runner.run_one('in', directory=hg_follower, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.errors) == 0
+    >>> if len(executor.parse_errors):
+    ...     for error in executor.parse_errors:
+    ...         error.print_msg()
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportIncoming)
+    >>> assert executor.reports[0].local_head.startswith('0:')
+    >>> assert executor.reports[0].remote_head.startswith('1:')
+    >>> assert len(executor.reports[0].changesets) == 1
+    >>> assert executor.reports[0].changesets[0].startswith('1:')
+
+
 Teardown:
 
     >>> os.chdir(orig_cwd)

--- a/checkoutmanager/tests/dirinfo_svn.rst
+++ b/checkoutmanager/tests/dirinfo_svn.rst
@@ -1,0 +1,88 @@
+
+.. :doctest:
+
+    >>> import subprocess
+    >>> import os
+    >>> from checkoutmanager.dirinfo import SvnDirInfo
+    >>> orig_cwd = os.getcwd()
+
+The tests will all run inside the homedir which the testsetup made for us:
+
+    >>> print(homedir)
+    HOMEDIR
+
+Create the config file:
+
+    >>> vcstest_config_path = os.path.join(homedir, 'vcstestconfig.cfg')
+    >>> import pkg_resources
+    >>> vcstest_config_tpath = pkg_resources.resource_filename(
+    ...     'checkoutmanager.tests', 'vcstestconfig.cfg.templ')
+    >>> with open(vcstest_config_tpath, 'r') as f:
+    ...     vcstest_config_tstr = str(f.read())
+    >>> import jinja2
+    >>> vcstest_config_t = jinja2.Template(vcstest_config_tstr)
+    >>> with open(vcstest_config_path, 'w') as f:
+    ...     lc = f.write(vcstest_config_t.render(homedir=homedir))
+    >>> from checkoutmanager import config
+    >>> conf = config.Config(vcstest_config_path)
+
+Make yourself a folder inside which all SVN tests will run:
+
+    >>> svn_repos_root = os.path.join(homedir, 'repos_svn')
+    >>> os.makedirs(svn_repos_root)
+    >>> print(svn_repos_root)
+    HOMEDIR/repos_svn
+
+Create an SVN repository:
+
+    >>> svn_upstream = os.path.join(svn_repos_root, 'a_repo')
+    >>> cmd = ['svnadmin', 'create', '--fs-type', 'fsfs', svn_upstream]
+    >>> subprocess.call(cmd)
+    0
+
+Create the working copies using checkoutmanager:
+
+    >>> svn_wc2 = os.path.join(svn_repos_root, 'wc2')
+    >>> svn_wc1 = os.path.join(svn_repos_root, 'wc1')
+    >>> from checkoutmanager import runner
+    >>> executor = runner.run_one('co', directory=svn_wc1, conf=conf)
+    >>> assert executor.errors == []
+    >>> executor = runner.run_one('co', directory=svn_wc2, conf=conf)
+    >>> assert executor.errors == []
+
+Create a file inside the first working copy and commit:
+
+    >>> os.chdir(svn_wc1)
+    >>> with open(os.path.join(svn_wc1, 'test_file'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> cmd = ['svn', 'add', 'test_file']
+    >>> subprocess.call(cmd)
+    >>> cmd = ['svn', 'ci', '-m', '\"one commit\"']
+    >>> subprocess.call(cmd)
+    >>> # SVN needs an up before the revision changes in the source
+    >>> # working copy.
+    >>> cmd = ['svn', 'up']
+    >>> subprocess.call(cmd)
+
+Tests for the 'rev' dirinfo action:
+
+    >>> # TODO Reintroduce when merged with collectors branch
+    >>> # from checkoutmanager import reports
+    >>> executor = runner.run_one('rev', directory=svn_wc1, conf=conf)
+    >>> # assert isinstance(executor.reports, list)
+    >>> # assert len(executor.reports) == 1
+    >>> # assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> # assert executor.reports[0].revision == 1
+    >>> executor = runner.run_one('rev', directory=svn_wc2, conf=conf)
+    >>> # assert isinstance(executor.reports, list)
+    >>> # assert len(executor.reports) == 1
+    >>> # assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> # assert executor.reports[0].revision == 0
+    >>> # TODO handle error conditons
+
+Teardown:
+
+    >>> os.chdir(orig_cwd)
+
+
+

--- a/checkoutmanager/tests/dirinfo_svn.rst
+++ b/checkoutmanager/tests/dirinfo_svn.rst
@@ -66,19 +66,35 @@ Create a file inside the first working copy and commit:
 
 Tests for the 'rev' dirinfo action:
 
-    >>> # TODO Reintroduce when merged with collectors branch
-    >>> # from checkoutmanager import reports
+    >>> from checkoutmanager import reports
     >>> executor = runner.run_one('rev', directory=svn_wc1, conf=conf)
-    >>> # assert isinstance(executor.reports, list)
-    >>> # assert len(executor.reports) == 1
-    >>> # assert isinstance(executor.reports[0], reports.ReportRevision)
-    >>> # assert executor.reports[0].revision == 1
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> assert executor.reports[0].revision == 1
     >>> executor = runner.run_one('rev', directory=svn_wc2, conf=conf)
-    >>> # assert isinstance(executor.reports, list)
-    >>> # assert len(executor.reports) == 1
-    >>> # assert isinstance(executor.reports[0], reports.ReportRevision)
-    >>> # assert executor.reports[0].revision == 0
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> assert executor.reports[0].revision == 0
     >>> # TODO handle error conditons
+
+Tests for the 'in' dirinfo action:
+
+    >>> executor = runner.run_one('in', directory=svn_wc2, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.errors) == 0
+    >>> if len(executor.parse_errors):
+    ...     for error in executor.parse_errors:
+    ...         error.print_msg()
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportIncoming)
+    >>> assert executor.reports[0].local_head == 0
+    >>> assert executor.reports[0].remote_head == 1
+    >>> assert len(executor.reports[0].changesets) == 1
+    >>> assert executor.reports[0].changesets[0] == 1
+
 
 Teardown:
 

--- a/checkoutmanager/tests/vcstestconfig.cfg.templ
+++ b/checkoutmanager/tests/vcstestconfig.cfg.templ
@@ -1,0 +1,37 @@
+# Sample config file.  Should be placed as
+# .checkoutmanager.cfg in your home directory.
+#
+# Different sections per base location
+# and version control system.  Splitting everything all over
+# the place in multiple directories is fine.
+
+[svn]
+vcs = svn
+basedir = ~/repos_svn/
+checkouts =
+    file:///{{ homedir }}/repos_svn/a_repo  wc1
+    file:///{{ homedir }}/repos_svn/a_repo  wc2
+
+[git]
+vcs = git
+basedir = ~/repos_git/
+checkouts =
+    /{{ homedir }}/repos_git/base
+    /{{ homedir }}/repos_git/base  follower
+    /{{ homedir }}/repos_git/base  leader
+
+[bzr]
+vcs = bzr
+basedir = ~/repos_bzr/
+checkouts =
+    /{{ homedir }}/repos_bzr/base
+    /{{ homedir }}/repos_bzr/base  follower
+    /{{ homedir }}/repos_bzr/base  leader
+
+[hg]
+vcs = hg
+basedir = ~/repos_hg/
+checkouts =
+    /{{ homedir }}/repos_hg/base
+    /{{ homedir }}/repos_hg/base  follower
+    /{{ homedir }}/repos_hg/base  leader

--- a/checkoutmanager/tests/vcstestconfig.cfg.templ
+++ b/checkoutmanager/tests/vcstestconfig.cfg.templ
@@ -16,7 +16,7 @@ checkouts =
 vcs = git
 basedir = ~/repos_git/
 checkouts =
-    /{{ homedir }}/repos_git/base
+    /{{ homedir }}/repos_git/base  base
     /{{ homedir }}/repos_git/base  follower
     /{{ homedir }}/repos_git/base  leader
 
@@ -24,7 +24,7 @@ checkouts =
 vcs = bzr
 basedir = ~/repos_bzr/
 checkouts =
-    /{{ homedir }}/repos_bzr/base
+    /{{ homedir }}/repos_bzr/base  base
     /{{ homedir }}/repos_bzr/base  follower
     /{{ homedir }}/repos_bzr/base  leader
 
@@ -32,6 +32,6 @@ checkouts =
 vcs = hg
 basedir = ~/repos_hg/
 checkouts =
-    /{{ homedir }}/repos_hg/base
-    /{{ homedir }}/repos_hg/base  follower
-    /{{ homedir }}/repos_hg/base  leader
+    file://{{ homedir }}/repos_hg/base  base
+    file://{{ homedir }}/repos_hg/base  follower
+    file://{{ homedir }}/repos_hg/base  leader

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(name='checkoutmanager',
           'test': [
               'z3c.testsetup>=0.3',
               'zope.testing',
+              'jinja2',
               ],
           },
       entry_points={


### PR DESCRIPTION
This commit introduces tests that include the VCS binaries. There are very few asserts, though, and in many cases failure will still show up as passed tests. Gross errors are caught, though, and additional tests will follow along with result collectors in a later PR (~3 days out).

See Issue #15 