### PR TITLE
Output parsers & report collection and summary 

### DIFF
--- a/checkoutmanager/dirinfo.py
+++ b/checkoutmanager/dirinfo.py
@@ -100,7 +100,24 @@ class DirInfo(object):
         raise NotImplementedError()
 
     def parse_co(self, output):
-        pass
+        lines = output.splitlines()
+        lines = [x.strip() for x in lines if x.strip()]
+        try:
+            line = lines[-1]
+        except IndexError:
+            raise reports.LineNotFoundError(self, "Checkout Result")
+        result, path = line.split(' ', 1)
+        if path.strip() != self.directory:
+            raise reports.DirectoryMismatchError(self, path)
+        if result.upper() == 'PRESENT':
+            raise reports.LogicalParseError(
+                self, output, "We expected the checkout to not exist!"
+            )
+        elif result.upper() == 'CREATED':
+            return reports.ReportCheckout(self)
+        else:
+            raise reports.LogicalParseError(
+                self, output, "Result isn't where we expect it to be.")
 
     def cmd_out(self):
         raise NotImplementedError()

--- a/checkoutmanager/dirinfo.py
+++ b/checkoutmanager/dirinfo.py
@@ -49,30 +49,57 @@ class DirInfo(object):
             answer = MISSING
         print(' '.join([answer, self.directory]))
 
+    def parse_exists(self, output):
+        pass
+
     def cmd_rev(self):
         raise NotImplementedError()
+
+    def parse_rev(self, output):
+        pass
 
     def cmd_in(self):
         raise NotImplementedError()
 
+    def parse_in(self, output):
+        pass
+
     def cmd_up(self):
         raise NotImplementedError()
+
+    def parse_up(self, output):
+        pass
 
     def cmd_st(self):
         raise NotImplementedError()
 
+    def parse_st(self, output):
+        pass
+
     def cmd_co(self):
         raise NotImplementedError()
 
+    def parse_co(self, output):
+        pass
+
     def cmd_out(self):
         raise NotImplementedError()
+
+    def parse_out(self, output):
+        pass
 
     def cmd_upgrade(self):
         # This is only useful for subversion.
         pass
 
+    def parse_upgrade(self, output):
+        pass
+
     def cmd_info(self):
         # This is only known to be useful for subversion.
+        pass
+
+    def parse_info(self, output):
         pass
 
 
@@ -411,7 +438,6 @@ class GitDirInfo(DirInfo):
             # TODO: check!
             print(system("git clone %s %s" % (
                 self.url, self.directory)))
-
         print(' '.join([answer, self.directory]))
 
     @capture_stdout

--- a/checkoutmanager/dirinfo.py
+++ b/checkoutmanager/dirinfo.py
@@ -7,6 +7,7 @@ import re
 from checkoutmanager.utils import CommandError
 from checkoutmanager.utils import capture_stdout
 from checkoutmanager.utils import system
+from checkoutmanager import reports
 
 # 8-char codes
 #         '12345678'
@@ -50,7 +51,13 @@ class DirInfo(object):
         print(' '.join([answer, self.directory]))
 
     def parse_exists(self, output):
-        pass
+        parts = output.split(' ', 1)
+        parts = [x.strip() for x in parts]
+        if parts[1] == self.directory:
+            if parts[0].upper() == 'PRESENT':
+                return reports.ReportExists(self, True)
+            if parts[0].upper() == 'ABSENT':
+                return reports.ReportExists(self, False)
 
     def cmd_rev(self):
         raise NotImplementedError()

--- a/checkoutmanager/dirinfo.py
+++ b/checkoutmanager/dirinfo.py
@@ -57,7 +57,7 @@ class DirInfo(object):
         if parts[1] == self.directory:
             if parts[0].upper() == 'PRESENT':
                 return reports.ReportExists(self, True)
-            if parts[0].upper() == 'ABSENT':
+            if parts[0].upper() == 'MISSING':
                 return reports.ReportExists(self, False)
         else:
             raise reports.DirectoryMismatchError(self, parts[1])

--- a/checkoutmanager/executors.py
+++ b/checkoutmanager/executors.py
@@ -26,8 +26,24 @@ class _Executor(object):
     def _collector(self, returned):
         """Collect a result.
 
+        The returned parameter is a ``tuple`` of ``(result, report)``.
+
+        ``result`` is the output of the command executed as returned by
+        cmd_*.
+
         If the result is a CommandError, save it for later, and print it's
-        message.  else, just print the result directly.
+        message. Else, just print the result directly.
+
+        ``report`` is a report of :class:``checkoutmanager.reports.ReportBase``,
+        returned by the parse_* functions. ``report`` could be ``None`` if the
+        parse function is not implemented, or be an instance of
+        :class:``checkoutmanager.reports.ParseError`` if there an error was
+        detected during parsing.
+
+        If the report is a valid :class:``checkoutmanager.reports.ReportBase``
+        object, it is saved for later within the executor object passed
+        on back to the caller. ParseErrors are saved as well along the lines
+        of CommandErrors.
 
         """
         result, report = returned

--- a/checkoutmanager/executors.py
+++ b/checkoutmanager/executors.py
@@ -6,6 +6,7 @@ from multiprocessing.pool import Pool
 import time
 
 from checkoutmanager import utils
+from checkoutmanager import reports
 
 
 def get_executor(single):
@@ -19,17 +20,24 @@ def get_executor(single):
 class _Executor(object):
     def __init__(self):
         self.errors = []
+        self.reports = []
+        self.parse_errors = []
 
-    def _collector(self, result):
+    def _collector(self, returned):
         """Collect a result.
 
         If the result is a CommandError, save it for later, and print it's
         message.  else, just print the result directly.
 
         """
+        result, report = returned
         if isinstance(result, utils.CommandError):
             self.errors.append(result)
             result = result.format_msg()
+        if isinstance(report, reports.ReportBase):
+            self.reports.append(report)
+        elif isinstance(report, reports.ParseError):
+            self.parse_errors.append(report)
         if not result:
             # Don't print empty lines
             return

--- a/checkoutmanager/executors.py
+++ b/checkoutmanager/executors.py
@@ -22,6 +22,7 @@ class _Executor(object):
         self.errors = []
         self.reports = []
         self.parse_errors = []
+        self.std_output = True
 
     def _collector(self, returned):
         """Collect a result.
@@ -57,7 +58,8 @@ class _Executor(object):
         if not result:
             # Don't print empty lines
             return
-        print(result)
+        if self.std_output:
+            print(result)
 
     def execute(self, func, args):
         """Execute the given function"""
@@ -66,6 +68,35 @@ class _Executor(object):
     def wait_for_results(self):
         """Make sure all results have been collected"""
         pass
+
+    def summarize(self, verbose=True):
+        print("checkoutmanager Run Summary : ")
+        print("----------------------------- ")
+        if len(self.errors):
+            if verbose:
+                print("Command Errors :")
+                print("----------------")
+            print("Encountered errors while running "
+                  "{0} commands".format(len(self.errors)))
+            if verbose:
+                for error in self.errors:
+                    print()
+                    print(error.print_msg())
+        if len(self.parse_errors):
+            if verbose:
+                print("Parse Errors :")
+                print("--------------")
+            print("Encountered errors while parsing output for "
+                  "{0} commands".format(len(self.parse_errors)))
+            if verbose:
+                for error in self.parse_errors:
+                    print()
+                    print(error.print_msg())
+        if len(self.reports):
+            if verbose:
+                print("Reports :")
+                print("---------")
+            print(reports.summarize(self.reports, reports))
 
 
 class _SingleExecutor(_Executor):

--- a/checkoutmanager/reports.py
+++ b/checkoutmanager/reports.py
@@ -1,0 +1,3 @@
+
+class ParseError(Exception):
+    pass

--- a/checkoutmanager/reports.py
+++ b/checkoutmanager/reports.py
@@ -47,6 +47,30 @@ class LineParseError(ParseError):
         print(self.format_msg())
 
 
+class FileStatus(object):
+    def __init__(self, filepath, status, moreinfo):
+        self.filepath = filepath
+        self.status = status
+        self.moreinfo = moreinfo
+
+    def __repr__(self):
+        if self.moreinfo is not None:
+            more = ' +'
+        else:
+            more = ''
+        return '<FileStatus {1} {0}{2}>'.format(self.filepath,
+                                                self.status, more)
+
+
+# class ChangeSet(object):
+#     def __init__(self, revision, changes=None):
+#         self.revision = revision
+#         self.changes = [FileStatus(*x) for x in changes]
+#
+#     def __repr__(self):
+#         return '<ChangeSet {0}>'.format(self.revision)
+
+
 class ReportBase(object):
     def __init__(self, dir_info):
         self.dir_info = dir_info
@@ -106,21 +130,6 @@ class ReportCheckout(ReportBase):
         return '<ReportCheckout {0}>'.format(self.dir_info.directory)
 
 
-class FileStatus(object):
-    def __init__(self, filepath, status, moreinfo):
-        self.filepath = filepath
-        self.status = status
-        self.moreinfo = moreinfo
-
-    def __repr__(self):
-        if self.moreinfo is not None:
-            more = ' +'
-        else:
-            more = ''
-        return '<FileStatus {1} {0}{2}>'.format(self.filepath,
-                                                self.status, more)
-
-
 class ReportStatus(ReportBase):
     def __init__(self, dir_info, changes):
         super(ReportStatus, self).__init__(dir_info)
@@ -128,4 +137,16 @@ class ReportStatus(ReportBase):
 
     def __repr__(self):
         return '<ReportStatus {0}: {1}>'.format(
+            self.dir_info.directory, repr(len(self.changes)))
+
+
+class ReportUpdate(ReportBase):
+    def __init__(self, dir_info, initial_head, final_head, changes):
+        super(ReportUpdate, self).__init__(dir_info)
+        self.initial_head = initial_head
+        self.final_head = final_head
+        self.changes = [FileStatus(*x) for x in changes]
+
+    def __repr__(self):
+        return '<ReportUpdate {0}: {1}>'.format(
             self.dir_info.directory, repr(len(self.changes)))

--- a/checkoutmanager/reports.py
+++ b/checkoutmanager/reports.py
@@ -4,6 +4,13 @@ class ParseError(Exception):
         self.dir_info = dir_info
 
 
+class LogicalParseError(Exception):
+    def __init__(self, dir_info, output, message):
+        self.dir_info = dir_info
+        self.output = output
+        self.message = message
+
+
 class DirectoryMismatchError(ParseError):
     def __init__(self, dir_info, got_dir):
         super(DirectoryMismatchError, self).__init__(dir_info)
@@ -21,6 +28,19 @@ class LineParseError(ParseError):
         super(LineParseError, self).__init__(dir_info)
         self.got_line = got_line
         self.parser = parser
+
+    def format_msg(self):
+        lines = []
+        lines.append("LineParseError occured")
+        lines.append(repr(self.dir_info))
+        lines.append("Got :")
+        lines.append(self.got_line)
+        lines.append("Tried to parse with :")
+        lines.append(repr(self.parser))
+        return "\n".join(lines)
+
+    def print_msg(self):
+        print(self.format_msg())
 
 
 class ReportBase(object):
@@ -46,3 +66,16 @@ class ReportRevision(ReportBase):
     def __repr__(self):
         return '<ReportRevision {0} {1}>'.format(repr(self.revision),
                                                  self.dir_info.directory)
+
+
+class ReportIncoming(ReportBase):
+    def __init__(self, dir_info, local_head, remote_head, changesets):
+        super(ReportIncoming, self).__init__(dir_info)
+        self.local_head = local_head
+        self.remote_head = remote_head
+        self.changesets = changesets
+
+    def __repr__(self):
+        return '<ReportIncoming {0} -{3}-> {1} {2}>'.format(
+            repr(self.local_head), repr(self.remote_head),
+            self.dir_info.directory, repr(len(self.changesets)))

--- a/checkoutmanager/reports.py
+++ b/checkoutmanager/reports.py
@@ -139,6 +139,11 @@ class ReportIncoming(ReportBase):
             repr(self.local_head), repr(self.remote_head),
             self.dir_info.directory, repr(len(self.changesets)))
 
+    def oneliner(self):
+        print('{0} <-{3}- {1} {2}').format(
+            repr(self.local_head), repr(self.remote_head),
+            self.dir_info.directory, repr(len(self.changesets)))
+
 
 class ReportOutgoing(ReportBase):
     def __init__(self, dir_info, local_head, remote_head, changesets):
@@ -149,6 +154,11 @@ class ReportOutgoing(ReportBase):
 
     def __repr__(self):
         return '<ReportOutgoing {0} -{3}-> {1} {2}>'.format(
+            repr(self.local_head), repr(self.remote_head),
+            self.dir_info.directory, repr(len(self.changesets)))
+
+    def oneliner(self):
+        print('{0} -{3}-> {1} {2}').format(
             repr(self.local_head), repr(self.remote_head),
             self.dir_info.directory, repr(len(self.changesets)))
 
@@ -181,3 +191,84 @@ class ReportUpdate(ReportBase):
     def __repr__(self):
         return '<ReportUpdate {0}: {1}>'.format(
             self.dir_info.directory, repr(len(self.changes)))
+
+
+def summarize(reports, verbose=False):
+    exists_reports = [x for x in reports if isinstance(x, ReportExists)]
+    revision_reports = [x for x in reports if isinstance(x, ReportRevision)]
+    incoming_reports = [x for x in reports if isinstance(x, ReportIncoming)]
+    outgoing_reports = [x for x in reports if isinstance(x, ReportOutgoing)]
+    checkout_reports = [x for x in reports if isinstance(x, ReportCheckout)]
+    status_reports = [x for x in reports if isinstance(x, ReportStatus)]
+    update_reports = [x for x in reports if isinstance(x, ReportUpdate)]
+
+    if len(exists_reports):
+        present_count = len([x for x in exists_reports if x.exists is True])
+        missing_count = len([x for x in exists_reports if x.exists is False])
+        if verbose:
+            print("Checkout Existence Reports :")
+        print("{0} of {1} checkouts exist, {2} missing".format(
+            present_count, len(exists_reports), missing_count))
+        if verbose and missing_count:
+            print("Missing Checkouts : ")
+            for report in exists_reports:
+                if not report.exists:
+                    print(report.dir_info.directory)
+        print()
+
+    if len(revision_reports):
+        print("Checkout Revisions :")
+        for report in revision_reports:
+            print("{0} : {1}".format(report.dir_info.directory, report.revision))
+        print()
+
+    if len(incoming_reports):
+        print("{0} repositories have Incoming Changesets :".format(
+            len(incoming_reports)))
+        for report in incoming_reports:
+            print(report.oneliner())
+            if verbose:
+                print("Incoming Changesets :")
+                for changeset in report.changesets:
+                    print(changeset)
+                print()
+
+    if len(outgoing_reports):
+        print("{0} repositories have Outgoing Changesets :".format(
+            len(outgoing_reports)))
+        for report in outgoing_reports:
+            print(report.oneliner())
+            if verbose:
+                print("Outgoing Changesets :")
+                for changeset in report.changesets:
+                    print(changeset)
+                print()
+
+    if len(checkout_reports):
+        print("{0} repositories have been checked out".format(
+            len(checkout_reports)))
+        for report in checkout_reports:
+            if verbose:
+                print('{0} from {1}'.format(
+                    report.dir_info.directory, report.dir_info.url))
+            else:
+                print(report.dir_info.directory)
+
+    if len(status_reports):
+        print("{0} repositories have uncommitted changes :".format(
+            len(status_reports)))
+        for report in status_reports:
+            print(report.dir_info.directory)
+            if verbose:
+                for change in report.changes:
+                    print(str(change.status) + str(change.filepath) + str(change.moreinfo))
+                print()
+
+    if len(update_reports):
+        print("{0} repositories were changed on update :".format(
+            len(update_reports)))
+        for report in update_reports:
+            print(report.dir_info.directory)
+            for change in report.changes:
+                print(str(change.status) + str(change.filepath) + str(change.moreinfo))
+            print()

--- a/checkoutmanager/reports.py
+++ b/checkoutmanager/reports.py
@@ -1,6 +1,26 @@
 
 class ParseError(Exception):
-    pass
+    def __init__(self, dir_info):
+        self.dir_info = dir_info
+
+
+class DirectoryMismatchError(ParseError):
+    def __init__(self, dir_info, got_dir):
+        super(DirectoryMismatchError, self).__init__(dir_info)
+        self.got_dir = got_dir
+
+
+class LineNotFoundError(ParseError):
+    def __init__(self, dir_info, line_not_found):
+        super(LineNotFoundError, self).__init__(dir_info)
+        self.line_not_found = line_not_found
+
+
+class LineParseError(ParseError):
+    def __init__(self, dir_info, got_line, parser):
+        super(LineParseError, self).__init__(dir_info)
+        self.got_line = got_line
+        self.parser = parser
 
 
 class ReportBase(object):
@@ -16,3 +36,13 @@ class ReportExists(ReportBase):
     def __repr__(self):
         return '<ReportExists {0} {1}>'.format(repr(self.exists),
                                                self.dir_info.directory)
+
+
+class ReportRevision(ReportBase):
+    def __init__(self, dir_info, revision):
+        super(ReportRevision, self).__init__(dir_info)
+        self.revision = revision
+
+    def __repr__(self):
+        return '<ReportRevision {0} {1}>'.format(repr(self.revision),
+                                                 self.dir_info.directory)

--- a/checkoutmanager/reports.py
+++ b/checkoutmanager/reports.py
@@ -3,12 +3,28 @@ class ParseError(Exception):
     def __init__(self, dir_info):
         self.dir_info = dir_info
 
+    def format_msg(self):
+        return []
+
+    def print_msg(self):
+        print(self.format_msg())
+
 
 class LogicalParseError(Exception):
     def __init__(self, dir_info, output, message):
         self.dir_info = dir_info
         self.output = output
         self.message = message
+
+    def format_msg(self):
+        lines = []
+        lines.append("LogicalParseError occured")
+        lines.append(repr(self.dir_info))
+        lines.append("Message :")
+        lines.append(self.message)
+        lines.append("Output :")
+        lines.append(self.output)
+        return "\n".join(lines)
 
 
 class DirectoryMismatchError(ParseError):
@@ -20,11 +36,29 @@ class DirectoryMismatchError(ParseError):
         return '<DirectoryMismatchError expected:{0} got:{1}>'.format(
             repr(self.dir_info.directory), repr(self.got_dir))
 
+    def format_msg(self):
+        lines = []
+        lines.append("DirectoryMismatchError occured")
+        lines.append(repr(self.dir_info))
+        lines.append("Expected :")
+        lines.append(self.dir_info.directory)
+        lines.append("Got :")
+        lines.append(self.got_dir)
+        return "\n".join(lines)
+
 
 class LineNotFoundError(ParseError):
     def __init__(self, dir_info, line_not_found):
         super(LineNotFoundError, self).__init__(dir_info)
         self.line_not_found = line_not_found
+
+    def format_msg(self):
+        lines = []
+        lines.append("LineNotFoundError occured")
+        lines.append(repr(self.dir_info))
+        lines.append("Could not find :")
+        lines.append(self.line_not_found)
+        return "\n".join(lines)
 
 
 class LineParseError(ParseError):
@@ -42,9 +76,6 @@ class LineParseError(ParseError):
         lines.append("Tried to parse with :")
         lines.append(repr(self.parser))
         return "\n".join(lines)
-
-    def print_msg(self):
-        print(self.format_msg())
 
 
 class FileStatus(object):

--- a/checkoutmanager/reports.py
+++ b/checkoutmanager/reports.py
@@ -16,6 +16,10 @@ class DirectoryMismatchError(ParseError):
         super(DirectoryMismatchError, self).__init__(dir_info)
         self.got_dir = got_dir
 
+    def __repr__(self):
+        return '<DirectoryMismatchError expected:{0} got:{1}>'.format(
+            repr(self.dir_info.directory), repr(self.got_dir))
+
 
 class LineNotFoundError(ParseError):
     def __init__(self, dir_info, line_not_found):
@@ -79,3 +83,11 @@ class ReportIncoming(ReportBase):
         return '<ReportIncoming {0} -{3}-> {1} {2}>'.format(
             repr(self.local_head), repr(self.remote_head),
             self.dir_info.directory, repr(len(self.changesets)))
+
+
+class ReportCheckout(ReportBase):
+    def __init__(self, dir_info):
+        super(ReportCheckout, self).__init__(dir_info)
+
+    def __repr__(self):
+        return '<ReportCheckout {0}>'.format(self.dir_info.directory)

--- a/checkoutmanager/reports.py
+++ b/checkoutmanager/reports.py
@@ -1,3 +1,18 @@
 
 class ParseError(Exception):
     pass
+
+
+class ReportBase(object):
+    def __init__(self, dir_info):
+        self.dir_info = dir_info
+
+
+class ReportExists(ReportBase):
+    def __init__(self, dir_info, exists):
+        super(ReportExists, self).__init__(dir_info)
+        self.exists = exists
+
+    def __repr__(self):
+        return '<ReportExists {0} {1}>'.format(repr(self.exists),
+                                               self.dir_info.directory)

--- a/checkoutmanager/reports.py
+++ b/checkoutmanager/reports.py
@@ -80,7 +80,20 @@ class ReportIncoming(ReportBase):
         self.changesets = changesets
 
     def __repr__(self):
-        return '<ReportIncoming {0} -{3}-> {1} {2}>'.format(
+        return '<ReportIncoming {0} <-{3}- {1} {2}>'.format(
+            repr(self.local_head), repr(self.remote_head),
+            self.dir_info.directory, repr(len(self.changesets)))
+
+
+class ReportOutgoing(ReportBase):
+    def __init__(self, dir_info, local_head, remote_head, changesets):
+        super(ReportOutgoing, self).__init__(dir_info)
+        self.local_head = local_head
+        self.remote_head = remote_head
+        self.changesets = changesets
+
+    def __repr__(self):
+        return '<ReportOutgoing {0} -{3}-> {1} {2}>'.format(
             repr(self.local_head), repr(self.remote_head),
             self.dir_info.directory, repr(len(self.changesets)))
 

--- a/checkoutmanager/reports.py
+++ b/checkoutmanager/reports.py
@@ -91,3 +91,28 @@ class ReportCheckout(ReportBase):
 
     def __repr__(self):
         return '<ReportCheckout {0}>'.format(self.dir_info.directory)
+
+
+class FileStatus(object):
+    def __init__(self, filepath, status, moreinfo):
+        self.filepath = filepath
+        self.status = status
+        self.moreinfo = moreinfo
+
+    def __repr__(self):
+        if self.moreinfo is not None:
+            more = ' +'
+        else:
+            more = ''
+        return '<FileStatus {1} {0}{2}>'.format(self.filepath,
+                                                self.status, more)
+
+
+class ReportStatus(ReportBase):
+    def __init__(self, dir_info, changes):
+        super(ReportStatus, self).__init__(dir_info)
+        self.changes = [FileStatus(*x) for x in changes]
+
+    def __repr__(self):
+        return '<ReportStatus {0}: {1}>'.format(
+            self.dir_info.directory, repr(len(self.changes)))

--- a/checkoutmanager/runner.py
+++ b/checkoutmanager/runner.py
@@ -113,7 +113,8 @@ def execute_action(dirinfo, custom_actions, action, report=True):
         return output, e
 
 
-def run_one(action, directory=None, url=None, conf=None, allow_ancestors=True, report=True):
+def run_one(action, directory=None, url=None, conf=None, allow_ancestors=True,
+            report=True, summarize=False, std_output=True, verbose=False):
     custom_actions = get_custom_actions()
     if not conf:
         conf = config.Config(os.path.expanduser(CONFIGFILE_NAME))
@@ -128,21 +129,41 @@ def run_one(action, directory=None, url=None, conf=None, allow_ancestors=True, r
     if not dir_info:
         raise RuntimeError(
             'Could not find the repository for %s!' % (directory or url))
+
+    if summarize is True or report is True:
+        # To summarize, reports must be generated
+        report = True
+    else:
+        report = False
+
     executor = get_executor(single=True)
+    executor.std_output = std_output
     executor.execute(execute_action, (dir_info, custom_actions, action, report))
     executor.wait_for_results()
+    if summarize is True:
+        executor.summarize(verbose)
     return executor
 
 
-def run(action, group=None, conf=None, single=False, report=True):
+def run(action, group=None, conf=None, single=False,
+        report=True, summarize=False, std_output=True, verbose=False):
     custom_actions = get_custom_actions()
     if not conf:
         conf = config.Config(os.path.expanduser(CONFIGFILE_NAME))
+
+    if summarize is True or report is True:
+        # To summarize, reports must be generated
+        report = True
+    else:
+        report = False
+
     executor = get_executor(single)
+    executor.std_output = std_output
     for dirinfo in conf.directories(group=group):
         executor.execute(execute_action, (dirinfo, custom_actions, action, report))
     executor.wait_for_results()
-
+    if summarize is True:
+        executor.summarize(verbose)
     return executor
 
 
@@ -215,7 +236,9 @@ def main():
                    group=group,
                    conf=conf,
                    single=options.single,
-                   report=False)
+                   summarize=True,
+                   std_output=True,
+                   verbose=False)
 
     if executor.errors:
         print()

--- a/checkoutmanager/runner.py
+++ b/checkoutmanager/runner.py
@@ -187,6 +187,9 @@ def main():
     parser.add_option("-s", "--single",
                       action="store_true", dest="single", default=False,
                       help="Execute actions in a single process")
+    parser.add_option("-l", "--full-output",
+                      action="store_true", dest="full_output", default=False,
+                      help="Don't summarize output")
     (options, args) = parser.parse_args()
     if options.verbose:
         utils.VERBOSE = True
@@ -232,13 +235,20 @@ def main():
         print("(Run 'checkoutmanager co' if found)")
         return
 
+    if options.full_output is True:
+        summarize = False
+        std_output = True
+    else:
+        summarize = True
+        std_output = False
+
     executor = run(action,
                    group=group,
                    conf=conf,
                    single=options.single,
                    report=False,
-                   summarize=False,
-                   std_output=True,
+                   summarize=summarize,
+                   std_output=std_output,
                    verbose=False)
 
     if executor.errors:

--- a/checkoutmanager/runner.py
+++ b/checkoutmanager/runner.py
@@ -236,7 +236,8 @@ def main():
                    group=group,
                    conf=conf,
                    single=options.single,
-                   summarize=True,
+                   report=False,
+                   summarize=False,
                    std_output=True,
                    verbose=False)
 

--- a/checkoutmanager/tests/dirinfo_bzr.rst
+++ b/checkoutmanager/tests/dirinfo_bzr.rst
@@ -1,0 +1,109 @@
+
+.. :doctest:
+
+    >>> import subprocess
+    >>> import os
+    >>> from checkoutmanager.dirinfo import GitDirInfo
+    >>> orig_cwd = os.getcwd()
+
+The tests will all run inside the homedir which the testsetup made for us:
+
+    >>> print(homedir)
+    HOMEDIR
+
+Create the config file:
+
+    >>> vcstest_config_path = os.path.join(homedir, 'vcstestconfig.cfg')
+    >>> import pkg_resources
+    >>> vcstest_config_tpath = pkg_resources.resource_filename(
+    ...     'checkoutmanager.tests', 'vcstestconfig.cfg.templ')
+    >>> with open(vcstest_config_tpath, 'r') as f:
+    ...     vcstest_config_tstr = str(f.read())
+    >>> import jinja2
+    >>> vcstest_config_t = jinja2.Template(vcstest_config_tstr)
+    >>> with open(vcstest_config_path, 'w') as f:
+    ...     lc = f.write(vcstest_config_t.render(homedir=homedir))
+    >>> from checkoutmanager import config
+    >>> conf = config.Config(vcstest_config_path)
+
+Make yourself a folder inside which all bzr tests will run:
+
+    >>> bzr_repos_root = os.path.join(homedir, 'repos_bzr')
+    >>> os.makedirs(bzr_repos_root)
+    >>> print(bzr_repos_root)
+    HOMEDIR/repos_bzr
+
+Initialize bzr:
+
+    >>> cmd = ['bzr', 'whoami', '\"Some Tester <someone@test.test>\"']
+    >>> subprocess.call(cmd)
+    0
+
+
+Create a bzr repository:
+
+    >>> bzr_base = os.path.join(bzr_repos_root, 'base')
+    >>> os.makedirs(bzr_base)
+    >>> cmd = ['bzr', 'init', bzr_base]
+    >>> subprocess.call(cmd)
+    0
+
+Create a file inside the base working copy and commit:
+
+    >>> os.chdir(bzr_base)
+    >>> with open(os.path.join(bzr_base, 'test_file'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> cmd = ['bzr', 'add', 'test_file']
+    >>> subprocess.call(cmd)
+    0
+    >>> cmd = ['bzr', 'commit', '-m', '\"one commit\"']
+    >>> subprocess.call(cmd)
+    0
+
+Create the other working copies using checkoutmanager:
+
+    >>> bzr_follower = os.path.join(bzr_repos_root, 'follower')
+    >>> bzr_leader = os.path.join(bzr_repos_root, 'leader')
+    >>> from checkoutmanager import runner
+    >>> executor = runner.run_one('co', directory=bzr_follower, conf=conf)
+    >>> # TODO Test Executor for CO Action
+    >>> assert executor.errors == []
+    >>> executor = runner.run_one('co', directory=bzr_leader, conf=conf)
+    >>> assert executor.errors == []
+
+Create commit on base to bring it ahead of the follower:
+
+    >>> os.chdir(bzr_base)
+    >>> with open(os.path.join(bzr_base, 'test_file_2'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> # TODO Run and Test for ST Action
+    >>> cmd = ['bzr', 'add', 'test_file_2']
+    >>> subprocess.call(cmd)
+    >>> cmd = ['bzr', 'commit', '-m', '\"second commit\"']
+    >>> subprocess.call(cmd)
+
+Update leader to bring it alongside base:
+
+    >>> from checkoutmanager import runner
+    >>> executor = runner.run_one('up', directory=bzr_leader, conf=conf)
+    >>> # TODO Test Executor for UP Action
+
+Create commit on leader to bring it ahead of the base:
+
+    >>> os.chdir(bzr_leader)
+    >>> with open(os.path.join(bzr_leader, 'test_file_3'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> # TODO Run and Test for ST Action
+    >>> cmd = ['bzr', 'add', 'test_file_3']
+    >>> subprocess.call(cmd)
+    >>> cmd = ['bzr', 'commit', '-m', '\"third commit\"']
+    >>> subprocess.call(cmd)
+
+The follower - leader - base hierarchy is now setup.
+
+Teardown:
+
+    >>> os.chdir(orig_cwd)
+
+
+

--- a/checkoutmanager/tests/dirinfo_bzr.rst
+++ b/checkoutmanager/tests/dirinfo_bzr.rst
@@ -139,7 +139,6 @@ Create another commit on leader to bring it ahead of the base:
     >>> assert os.getcwd() == '{0}/repos_bzr/leader'.format(homedir)
     >>> with open(os.path.join(bzr_leader, 'test_file_3'), 'w+') as f:
     ...     f.writelines('Foo')
-    >>> # TODO Run and Test for ST Action
     >>> cmd = ['bzr', 'add', 'test_file_3']
     >>> subprocess.call(cmd)
     >>> cmd = ['bzr', 'commit', '-m', '\"third commit\"']

--- a/checkoutmanager/tests/dirinfo_bzr.rst
+++ b/checkoutmanager/tests/dirinfo_bzr.rst
@@ -65,11 +65,19 @@ Create the other working copies using checkoutmanager:
     >>> bzr_follower = os.path.join(bzr_repos_root, 'follower')
     >>> bzr_leader = os.path.join(bzr_repos_root, 'leader')
     >>> from checkoutmanager import runner
+    >>> from checkoutmanager import reports
     >>> executor = runner.run_one('co', directory=bzr_follower, conf=conf)
-    >>> # TODO Test Executor for CO Action
     >>> assert executor.errors == []
+    >>> assert executor.parse_errors == []
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportCheckout)
     >>> executor = runner.run_one('co', directory=bzr_leader, conf=conf)
     >>> assert executor.errors == []
+    >>> assert executor.parse_errors == []
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportCheckout)
     >>> # bzr checkouts are bound. There is probably some scope here
     >>> # for a discussion about the consequences of bzr branch vs bzr checkout,
     >>> # in terms of behavior of in, out, up. It seems bzr checkout is akin to a

--- a/checkoutmanager/tests/dirinfo_bzr.rst
+++ b/checkoutmanager/tests/dirinfo_bzr.rst
@@ -60,7 +60,7 @@ Create a file inside the base working copy and commit:
     >>> subprocess.call(cmd)
     0
 
-Create the other working copies using checkoutmanager:
+Test the 'co' dirinfo action. Create the other working copies using checkoutmanager:
 
     >>> bzr_follower = os.path.join(bzr_repos_root, 'follower')
     >>> bzr_leader = os.path.join(bzr_repos_root, 'leader')
@@ -88,16 +88,43 @@ Create the other working copies using checkoutmanager:
     >>> os.chdir(bzr_leader)
     >>> subprocess.call(cmd)
 
-Create commit on base to bring it ahead of the follower:
+Test the 'st' dirinfo action. Create commit on base to bring it ahead of the follower:
 
     >>> os.chdir(bzr_base)
     >>> with open(os.path.join(bzr_base, 'test_file_2'), 'w+') as f:
     ...     f.writelines('Foo')
-    >>> # TODO Run and Test for ST Action
+    >>> executor = runner.run_one('st', directory=bzr_base, conf=conf)
+    >>> assert len(executor.errors) == 0
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> report = executor.reports[0]
+    >>> assert isinstance(report, reports.ReportStatus)
+    >>> assert len(report.changes) == 1
+    >>> change = report.changes[0]
+    >>> assert isinstance(change, reports.FileStatus)
+    >>> assert change.filepath == 'test_file_2'
+    >>> assert change.status == 'unknown'
+    >>> assert not change.moreinfo
     >>> cmd = ['bzr', 'add', 'test_file_2']
     >>> subprocess.call(cmd)
+    >>> executor = runner.run_one('st', directory=bzr_base, conf=conf)
+    >>> assert len(executor.errors) == 0
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> report = executor.reports[0]
+    >>> assert isinstance(report, reports.ReportStatus)
+    >>> assert len(report.changes) == 1
+    >>> change = report.changes[0]
+    >>> assert isinstance(change, reports.FileStatus)
+    >>> assert change.filepath == 'test_file_2'
+    >>> assert change.status == 'added'
+    >>> assert not change.moreinfo
     >>> cmd = ['bzr', 'commit', '-m', '\"second commit\"']
     >>> subprocess.call(cmd)
+    >>> executor = runner.run_one('st', directory=bzr_base, conf=conf)
+    >>> assert len(executor.errors) == 0
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 0
 
 Update leader to bring it alongside base. Since we unbound the repo, we need to
 ``pull``, not ``up`` to get the commit here :
@@ -120,7 +147,7 @@ Create another commit on leader to bring it ahead of the base:
 
 The follower - leader - base hierarchy is now setup.
 
-Tests for the 'rev' dirinfo action:
+Test for the 'rev' dirinfo action:
 
     >>> from checkoutmanager import reports
     >>> executor = runner.run_one('rev', directory=bzr_base, conf=conf)

--- a/checkoutmanager/tests/dirinfo_bzr.rst
+++ b/checkoutmanager/tests/dirinfo_bzr.rst
@@ -149,7 +149,6 @@ The follower - leader - base hierarchy is now setup.
 
 Test for the 'rev' dirinfo action:
 
-    >>> from checkoutmanager import reports
     >>> executor = runner.run_one('rev', directory=bzr_base, conf=conf)
     >>> assert isinstance(executor.reports, list)
     >>> assert len(executor.reports) == 1
@@ -166,6 +165,19 @@ Test for the 'rev' dirinfo action:
     >>> assert isinstance(executor.reports[0], reports.ReportRevision)
     >>> assert executor.reports[0].revision == 1
     >>> # TODO handle error conditons
+
+Test for the 'out' dirinfo action:
+
+    >>> executor = runner.run_one('out', directory=bzr_leader, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> report = executor.reports[0]
+    >>> assert isinstance(report, reports.ReportOutgoing)
+    >>> assert report.local_head == 3
+    >>> assert not report.remote_head
+    >>> assert isinstance(report.changesets, list)
+    >>> assert len(report.changesets) == 1
+    >>> assert report.changesets[0] == 3
 
 Teardown:
 

--- a/checkoutmanager/tests/dirinfo_git.rst
+++ b/checkoutmanager/tests/dirinfo_git.rst
@@ -103,6 +103,41 @@ Create commit on leader to bring it ahead of the base:
 
 The follower - leader - base hierarchy is now setup.
 
+Tests for the 'rev' dirinfo action:
+
+    >>> from checkoutmanager import reports
+    >>> executor = runner.run_one('rev', directory=git_base, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> assert isinstance(executor.reports[0].revision, str)
+    >>> executor = runner.run_one('rev', directory=git_leader, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> assert isinstance(executor.reports[0].revision, str)
+    >>> executor = runner.run_one('rev', directory=git_follower, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> assert isinstance(executor.reports[0].revision, str)
+    >>> # TODO handle error conditons
+
+Tests for the 'in' dirinfo action:
+
+    >>> executor = runner.run_one('in', directory=git_follower, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.errors) == 0
+    >>> if len(executor.parse_errors):
+    ...     for error in executor.parse_errors:
+    ...         error.print_msg()
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportIncoming)
+    >>> assert isinstance(executor.reports[0].local_head, str)
+    >>> assert isinstance(executor.reports[0].remote_head, str)
+    >>> assert len(executor.reports[0].changesets) == 0
+
 Teardown:
 
     >>> os.chdir(orig_cwd)

--- a/checkoutmanager/tests/dirinfo_git.rst
+++ b/checkoutmanager/tests/dirinfo_git.rst
@@ -1,0 +1,111 @@
+
+.. :doctest:
+
+    >>> import subprocess
+    >>> import os
+    >>> from checkoutmanager.dirinfo import GitDirInfo
+    >>> orig_cwd = os.getcwd()
+
+The tests will all run inside the homedir which the testsetup made for us:
+
+    >>> print(homedir)
+    HOMEDIR
+
+Create the config file:
+
+    >>> vcstest_config_path = os.path.join(homedir, 'vcstestconfig.cfg')
+    >>> import pkg_resources
+    >>> vcstest_config_tpath = pkg_resources.resource_filename(
+    ...     'checkoutmanager.tests', 'vcstestconfig.cfg.templ')
+    >>> with open(vcstest_config_tpath, 'r') as f:
+    ...     vcstest_config_tstr = str(f.read())
+    >>> import jinja2
+    >>> vcstest_config_t = jinja2.Template(vcstest_config_tstr)
+    >>> with open(vcstest_config_path, 'w') as f:
+    ...     lc = f.write(vcstest_config_t.render(homedir=homedir))
+    >>> from checkoutmanager import config
+    >>> conf = config.Config(vcstest_config_path)
+
+Make yourself a folder inside which all git tests will run:
+
+    >>> git_repos_root = os.path.join(homedir, 'repos_git')
+    >>> os.makedirs(git_repos_root)
+    >>> print(git_repos_root)
+    HOMEDIR/repos_git
+
+Initialize git:
+
+    >>> cmd = ['git', 'config', '--global', 'user.email', '\"someone@test.test\"']
+    >>> subprocess.call(cmd)
+    0
+    >>> cmd = ['git', 'config', '--global', 'user.name', '\"Some Tester\"']
+    >>> subprocess.call(cmd)
+    0
+
+Create a git repository:
+
+    >>> git_base = os.path.join(git_repos_root, 'base')
+    >>> os.makedirs(git_base)
+    >>> cmd = ['git', 'init', git_base]
+    >>> subprocess.call(cmd)
+    0
+
+Create a file inside the base working copy and commit:
+
+    >>> os.chdir(git_base)
+    >>> with open(os.path.join(git_base, 'test_file'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> cmd = ['git', 'add', 'test_file']
+    >>> subprocess.call(cmd)
+    0
+    >>> cmd = ['git', 'commit', '-m', '\"one commit\"']
+    >>> subprocess.call(cmd)
+    0
+
+Create the other working copies using checkoutmanager:
+
+    >>> git_follower = os.path.join(git_repos_root, 'follower')
+    >>> git_leader = os.path.join(git_repos_root, 'leader')
+    >>> from checkoutmanager import runner
+    >>> executor = runner.run_one('co', directory=git_follower, conf=conf)
+    >>> # TODO Test Executor for CO Action
+    >>> assert executor.errors == []
+    >>> executor = runner.run_one('co', directory=git_leader, conf=conf)
+    >>> assert executor.errors == []
+
+Create commit on base to bring it ahead of the follower:
+
+    >>> os.chdir(git_base)
+    >>> with open(os.path.join(git_base, 'test_file_2'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> # TODO Run and Test for ST Action
+    >>> cmd = ['git', 'add', 'test_file_2']
+    >>> subprocess.call(cmd)
+    >>> cmd = ['git', 'commit', '-m', '\"second commit\"']
+    >>> subprocess.call(cmd)
+
+Update leader to bring it alongside base:
+
+    >>> from checkoutmanager import runner
+    >>> executor = runner.run_one('up', directory=git_leader, conf=conf)
+    >>> # TODO Test Executor for UP Action
+
+Create commit on leader to bring it ahead of the base:
+
+    >>> os.chdir(git_leader)
+    >>> with open(os.path.join(git_leader, 'test_file_3'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> # TODO Run and Test for ST Action
+    >>> cmd = ['git', 'add', 'test_file_3']
+    >>> subprocess.call(cmd)
+    >>> cmd = ['git', 'commit', '-m', '\"third commit\"']
+    >>> subprocess.call(cmd)
+
+The follower - leader - base hierarchy is now setup.
+
+Teardown:
+
+    >>> os.chdir(orig_cwd)
+
+
+

--- a/checkoutmanager/tests/dirinfo_git.rst
+++ b/checkoutmanager/tests/dirinfo_git.rst
@@ -62,7 +62,7 @@ Create a file inside the base working copy and commit:
     >>> subprocess.call(cmd)
     0
 
-Create the other working copies using checkoutmanager:
+Test the 'co' dirinfo action. Create the other working copies using checkoutmanager:
 
     >>> git_follower = os.path.join(git_repos_root, 'follower')
     >>> git_leader = os.path.join(git_repos_root, 'leader')
@@ -81,16 +81,43 @@ Create the other working copies using checkoutmanager:
     >>> assert len(executor.reports) == 1
     >>> assert isinstance(executor.reports[0], reports.ReportCheckout)
 
-Create commit on base to bring it ahead of the follower:
+Test the 'st' dirinfo action. Create commit on base to bring it ahead of the follower:
 
     >>> os.chdir(git_base)
     >>> with open(os.path.join(git_base, 'test_file_2'), 'w+') as f:
     ...     f.writelines('Foo')
-    >>> # TODO Run and Test for ST Action
+    >>> executor = runner.run_one('st', directory=git_base, conf=conf)
+    >>> assert len(executor.errors) == 0
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> report = executor.reports[0]
+    >>> assert isinstance(report, reports.ReportStatus)
+    >>> assert len(report.changes) == 1
+    >>> change = report.changes[0]
+    >>> assert isinstance(change, reports.FileStatus)
+    >>> assert change.filepath == 'test_file_2'
+    >>> assert change.status == '??'
+    >>> assert not change.moreinfo
     >>> cmd = ['git', 'add', 'test_file_2']
     >>> subprocess.call(cmd)
+    >>> executor = runner.run_one('st', directory=git_base, conf=conf)
+    >>> assert len(executor.errors) == 0
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> report = executor.reports[0]
+    >>> assert isinstance(report, reports.ReportStatus)
+    >>> assert len(report.changes) == 1
+    >>> change = report.changes[0]
+    >>> assert isinstance(change, reports.FileStatus)
+    >>> assert change.filepath == 'test_file_2'
+    >>> assert change.status == 'A '
+    >>> assert not change.moreinfo
     >>> cmd = ['git', 'commit', '-m', '\"second commit\"']
     >>> subprocess.call(cmd)
+    >>> executor = runner.run_one('st', directory=git_base, conf=conf)
+    >>> assert len(executor.errors) == 0
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 0
 
 Update leader to bring it alongside base:
 

--- a/checkoutmanager/tests/dirinfo_git.rst
+++ b/checkoutmanager/tests/dirinfo_git.rst
@@ -41,6 +41,9 @@ Initialize git:
     >>> cmd = ['git', 'config', '--global', 'user.name', '\"Some Tester\"']
     >>> subprocess.call(cmd)
     0
+    >>> cmd = ['git', 'config', '--global', 'push.default', 'simple']
+    >>> subprocess.call(cmd)
+    0
 
 Create a git repository:
 
@@ -123,14 +126,25 @@ Update leader to bring it alongside base:
 
     >>> from checkoutmanager import runner
     >>> executor = runner.run_one('up', directory=git_leader, conf=conf)
-    >>> # TODO Test Executor for UP Action
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.errors) == 0
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportUpdate)
+    >>> assert isinstance(executor.reports[0].initial_head, str)
+    >>> assert isinstance(executor.reports[0].final_head, str)
+    >>> assert len(executor.reports[0].changes) == 1
+    >>> change = executor.reports[0].changes[0]
+    >>> assert isinstance(change, reports.FileStatus)
+    >>> assert change.filepath == 'test_file_2'
+    >>> assert change.status == '1 +'
+    >>> assert not change.moreinfo
 
 Create commit on leader to bring it ahead of the base:
 
     >>> os.chdir(git_leader)
     >>> with open(os.path.join(git_leader, 'test_file_3'), 'w+') as f:
     ...     f.writelines('Foo')
-    >>> # TODO Run and Test for ST Action
     >>> cmd = ['git', 'add', 'test_file_3']
     >>> subprocess.call(cmd)
     >>> cmd = ['git', 'commit', '-m', '\"third commit\"']
@@ -156,7 +170,6 @@ Tests for the 'rev' dirinfo action:
     >>> assert len(executor.reports) == 1
     >>> assert isinstance(executor.reports[0], reports.ReportRevision)
     >>> assert isinstance(executor.reports[0].revision, str)
-    >>> # TODO handle error conditons
 
 Tests for the 'in' dirinfo action:
 
@@ -187,7 +200,6 @@ Tests for the 'out' dirinfo action:
     >>> assert isinstance(executor.reports[0].local_head, str)
     >>> assert isinstance(executor.reports[0].remote_head, str)
     >>> assert len(executor.reports[0].changesets) == 0
-
 
 Teardown:
 

--- a/checkoutmanager/tests/dirinfo_git.rst
+++ b/checkoutmanager/tests/dirinfo_git.rst
@@ -173,6 +173,22 @@ Tests for the 'in' dirinfo action:
     >>> assert isinstance(executor.reports[0].remote_head, str)
     >>> assert len(executor.reports[0].changesets) == 0
 
+Tests for the 'out' dirinfo action:
+
+    >>> executor = runner.run_one('out', directory=git_leader, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.errors) == 0
+    >>> if len(executor.parse_errors):
+    ...     for error in executor.parse_errors:
+    ...         error.print_msg()
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportOutgoing)
+    >>> assert isinstance(executor.reports[0].local_head, str)
+    >>> assert isinstance(executor.reports[0].remote_head, str)
+    >>> assert len(executor.reports[0].changesets) == 0
+
+
 Teardown:
 
     >>> os.chdir(orig_cwd)

--- a/checkoutmanager/tests/dirinfo_git.rst
+++ b/checkoutmanager/tests/dirinfo_git.rst
@@ -67,11 +67,19 @@ Create the other working copies using checkoutmanager:
     >>> git_follower = os.path.join(git_repos_root, 'follower')
     >>> git_leader = os.path.join(git_repos_root, 'leader')
     >>> from checkoutmanager import runner
+    >>> from checkoutmanager import reports
     >>> executor = runner.run_one('co', directory=git_follower, conf=conf)
-    >>> # TODO Test Executor for CO Action
     >>> assert executor.errors == []
+    >>> assert executor.parse_errors == []
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportCheckout)
     >>> executor = runner.run_one('co', directory=git_leader, conf=conf)
     >>> assert executor.errors == []
+    >>> assert executor.parse_errors == []
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportCheckout)
 
 Create commit on base to bring it ahead of the follower:
 

--- a/checkoutmanager/tests/dirinfo_hg.rst
+++ b/checkoutmanager/tests/dirinfo_hg.rst
@@ -116,18 +116,29 @@ Test the 'st' dirinfo action. Create commit on base to bring it ahead of the fol
     >>> assert len(executor.parse_errors) == 0
     >>> assert len(executor.reports) == 0
 
-Update leader to bring it alongside base:
+Test the 'up' dirinfo action. Update leader to bring it alongside base:
 
     >>> from checkoutmanager import runner
     >>> executor = runner.run_one('up', directory=hg_leader, conf=conf)
-    >>> # TODO Test Executor for UP Action
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.errors) == 0
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportUpdate)
+    >>> assert not executor.reports[0].initial_head
+    >>> assert isinstance(executor.reports[0].final_head, str)
+    >>> assert len(executor.reports[0].changes) == 1
+    >>> change = executor.reports[0].changes[0]
+    >>> assert isinstance(change, reports.FileStatus)
+    >>> assert not change.filepath
+    >>> assert change.status == 'updated'
+    >>> assert not change.moreinfo
 
 Create commit on leader to bring it ahead of the base:
 
     >>> os.chdir(hg_leader)
     >>> with open(os.path.join(hg_leader, 'test_file_3'), 'w+') as f:
     ...     f.writelines('Foo')
-    >>> # TODO Run and Test for ST Action
     >>> cmd = ['hg', 'add', 'test_file_3']
     >>> subprocess.call(cmd)
     >>> cmd = ['hg', 'commit', '-m', '\"third commit\"']
@@ -160,9 +171,6 @@ Tests for the 'in' dirinfo action:
     >>> executor = runner.run_one('in', directory=hg_follower, conf=conf)
     >>> assert isinstance(executor.reports, list)
     >>> assert len(executor.errors) == 0
-    >>> if len(executor.parse_errors):
-    ...     for error in executor.parse_errors:
-    ...         error.print_msg()
     >>> assert len(executor.parse_errors) == 0
     >>> assert len(executor.reports) == 1
     >>> assert isinstance(executor.reports[0], reports.ReportIncoming)
@@ -176,9 +184,6 @@ Tests for the 'out' dirinfo action:
     >>> executor = runner.run_one('out', directory=hg_leader, conf=conf)
     >>> assert isinstance(executor.reports, list)
     >>> assert len(executor.errors) == 0
-    >>> if len(executor.parse_errors):
-    ...     for error in executor.parse_errors:
-    ...         error.print_msg()
     >>> assert len(executor.parse_errors) == 0
     >>> assert len(executor.reports) == 1
     >>> assert isinstance(executor.reports[0], reports.ReportOutgoing)

--- a/checkoutmanager/tests/dirinfo_hg.rst
+++ b/checkoutmanager/tests/dirinfo_hg.rst
@@ -171,6 +171,22 @@ Tests for the 'in' dirinfo action:
     >>> assert len(executor.reports[0].changesets) == 1
     >>> assert executor.reports[0].changesets[0].startswith('1:')
 
+Tests for the 'out' dirinfo action:
+
+    >>> executor = runner.run_one('out', directory=hg_leader, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.errors) == 0
+    >>> if len(executor.parse_errors):
+    ...     for error in executor.parse_errors:
+    ...         error.print_msg()
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportOutgoing)
+    >>> assert executor.reports[0].local_head.startswith('2:')
+    >>> assert not executor.reports[0].remote_head
+    >>> assert len(executor.reports[0].changesets) == 1
+    >>> assert executor.reports[0].changesets[0].startswith('2:')
+
 
 Teardown:
 

--- a/checkoutmanager/tests/dirinfo_hg.rst
+++ b/checkoutmanager/tests/dirinfo_hg.rst
@@ -1,0 +1,108 @@
+
+.. :doctest:
+
+    >>> import subprocess
+    >>> import os
+    >>> from checkoutmanager.dirinfo import GitDirInfo
+    >>> orig_cwd = os.getcwd()
+
+The tests will all run inside the homedir which the testsetup made for us:
+
+    >>> print(homedir)
+    HOMEDIR
+
+Create the config file:
+
+    >>> vcstest_config_path = os.path.join(homedir, 'vcstestconfig.cfg')
+    >>> import pkg_resources
+    >>> vcstest_config_tpath = pkg_resources.resource_filename(
+    ...     'checkoutmanager.tests', 'vcstestconfig.cfg.templ')
+    >>> with open(vcstest_config_tpath, 'r') as f:
+    ...     vcstest_config_tstr = str(f.read())
+    >>> import jinja2
+    >>> vcstest_config_t = jinja2.Template(vcstest_config_tstr)
+    >>> with open(vcstest_config_path, 'w') as f:
+    ...     lc = f.write(vcstest_config_t.render(homedir=homedir))
+    >>> from checkoutmanager import config
+    >>> conf = config.Config(vcstest_config_path)
+
+Make yourself a folder inside which all hg tests will run:
+
+    >>> hg_repos_root = os.path.join(homedir, 'repos_hg')
+    >>> os.makedirs(hg_repos_root)
+    >>> print(hg_repos_root)
+    HOMEDIR/repos_hg
+
+Initialize hg:
+
+    >>> with open(os.path.join(homedir, '.hgrc'), 'w') as f:
+    ...     f.writelines("[ui]\n")
+    ...     f.writelines("username = Some Tester <someone@test.test\n")
+
+Create a hg repository:
+
+    >>> hg_base = os.path.join(hg_repos_root, 'base')
+    >>> os.makedirs(hg_base)
+    >>> cmd = ['hg', 'init', hg_base]
+    >>> subprocess.call(cmd)
+    0
+
+Create a file inside the base working copy and commit:
+
+    >>> os.chdir(hg_base)
+    >>> with open(os.path.join(hg_base, 'test_file'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> cmd = ['hg', 'add', 'test_file']
+    >>> subprocess.call(cmd)
+    0
+    >>> cmd = ['hg', 'commit', '-m', '\"one commit\"']
+    >>> subprocess.call(cmd)
+    0
+
+Create the other working copies using checkoutmanager:
+
+    >>> hg_follower = os.path.join(hg_repos_root, 'follower')
+    >>> hg_leader = os.path.join(hg_repos_root, 'leader')
+    >>> from checkoutmanager import runner
+    >>> executor = runner.run_one('co', directory=hg_follower, conf=conf)
+    >>> # TODO Test Executor for CO Action
+    >>> assert executor.errors == []
+    >>> executor = runner.run_one('co', directory=hg_leader, conf=conf)
+    >>> assert executor.errors == []
+
+Create commit on base to bring it ahead of the follower:
+
+    >>> os.chdir(hg_base)
+    >>> with open(os.path.join(hg_base, 'test_file_2'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> # TODO Run and Test for ST Action
+    >>> cmd = ['hg', 'add', 'test_file_2']
+    >>> subprocess.call(cmd)
+    >>> cmd = ['hg', 'commit', '-m', '\"second commit\"']
+    >>> subprocess.call(cmd)
+
+Update leader to bring it alongside base:
+
+    >>> from checkoutmanager import runner
+    >>> executor = runner.run_one('up', directory=hg_leader, conf=conf)
+    >>> # TODO Test Executor for UP Action
+
+Create commit on leader to bring it ahead of the base:
+
+    >>> os.chdir(hg_leader)
+    >>> with open(os.path.join(hg_leader, 'test_file_3'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> # TODO Run and Test for ST Action
+    >>> cmd = ['hg', 'add', 'test_file_3']
+    >>> subprocess.call(cmd)
+    >>> cmd = ['hg', 'commit', '-m', '\"third commit\"']
+    >>> subprocess.call(cmd)
+
+The follower - leader - base hierarchy is now setup.
+
+Teardown:
+
+    >>> os.chdir(orig_cwd)
+
+
+

--- a/checkoutmanager/tests/dirinfo_hg.rst
+++ b/checkoutmanager/tests/dirinfo_hg.rst
@@ -59,7 +59,7 @@ Create a file inside the base working copy and commit:
     >>> subprocess.call(cmd)
     0
 
-Create the other working copies using checkoutmanager:
+Test the 'co' dirinfo action. Create the other working copies using checkoutmanager:
 
     >>> hg_follower = os.path.join(hg_repos_root, 'follower')
     >>> hg_leader = os.path.join(hg_repos_root, 'leader')
@@ -78,16 +78,43 @@ Create the other working copies using checkoutmanager:
     >>> assert len(executor.reports) == 1
     >>> assert isinstance(executor.reports[0], reports.ReportCheckout)
 
-Create commit on base to bring it ahead of the follower:
+Test the 'st' dirinfo action. Create commit on base to bring it ahead of the follower:
 
     >>> os.chdir(hg_base)
     >>> with open(os.path.join(hg_base, 'test_file_2'), 'w+') as f:
     ...     f.writelines('Foo')
-    >>> # TODO Run and Test for ST Action
+    >>> executor = runner.run_one('st', directory=hg_base, conf=conf)
+    >>> assert len(executor.errors) == 0
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> report = executor.reports[0]
+    >>> assert isinstance(report, reports.ReportStatus)
+    >>> assert len(report.changes) == 1
+    >>> change = report.changes[0]
+    >>> assert isinstance(change, reports.FileStatus)
+    >>> assert change.filepath == 'test_file_2'
+    >>> assert change.status == '?'
+    >>> assert not change.moreinfo
     >>> cmd = ['hg', 'add', 'test_file_2']
     >>> subprocess.call(cmd)
+    >>> executor = runner.run_one('st', directory=hg_base, conf=conf)
+    >>> assert len(executor.errors) == 0
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> report = executor.reports[0]
+    >>> assert isinstance(report, reports.ReportStatus)
+    >>> assert len(report.changes) == 1
+    >>> change = report.changes[0]
+    >>> assert isinstance(change, reports.FileStatus)
+    >>> assert change.filepath == 'test_file_2'
+    >>> assert change.status == 'A'
+    >>> assert not change.moreinfo
     >>> cmd = ['hg', 'commit', '-m', '\"second commit\"']
     >>> subprocess.call(cmd)
+    >>> executor = runner.run_one('st', directory=hg_base, conf=conf)
+    >>> assert len(executor.errors) == 0
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 0
 
 Update leader to bring it alongside base:
 

--- a/checkoutmanager/tests/dirinfo_hg.rst
+++ b/checkoutmanager/tests/dirinfo_hg.rst
@@ -100,6 +100,43 @@ Create commit on leader to bring it ahead of the base:
 
 The follower - leader - base hierarchy is now setup.
 
+Tests for the 'rev' dirinfo action:
+
+    >>> from checkoutmanager import reports
+    >>> executor = runner.run_one('rev', directory=hg_base, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> assert executor.reports[0].revision.startswith('1:')
+    >>> executor = runner.run_one('rev', directory=hg_leader, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> assert executor.reports[0].revision.startswith('2:')
+    >>> executor = runner.run_one('rev', directory=hg_follower, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> assert executor.reports[0].revision.startswith('0:')
+    >>> # TODO handle error conditons
+
+Tests for the 'in' dirinfo action:
+
+    >>> executor = runner.run_one('in', directory=hg_follower, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.errors) == 0
+    >>> if len(executor.parse_errors):
+    ...     for error in executor.parse_errors:
+    ...         error.print_msg()
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportIncoming)
+    >>> assert executor.reports[0].local_head.startswith('0:')
+    >>> assert executor.reports[0].remote_head.startswith('1:')
+    >>> assert len(executor.reports[0].changesets) == 1
+    >>> assert executor.reports[0].changesets[0].startswith('1:')
+
+
 Teardown:
 
     >>> os.chdir(orig_cwd)

--- a/checkoutmanager/tests/dirinfo_hg.rst
+++ b/checkoutmanager/tests/dirinfo_hg.rst
@@ -64,11 +64,19 @@ Create the other working copies using checkoutmanager:
     >>> hg_follower = os.path.join(hg_repos_root, 'follower')
     >>> hg_leader = os.path.join(hg_repos_root, 'leader')
     >>> from checkoutmanager import runner
+    >>> from checkoutmanager import reports
     >>> executor = runner.run_one('co', directory=hg_follower, conf=conf)
-    >>> # TODO Test Executor for CO Action
     >>> assert executor.errors == []
+    >>> assert executor.parse_errors == []
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportCheckout)
     >>> executor = runner.run_one('co', directory=hg_leader, conf=conf)
     >>> assert executor.errors == []
+    >>> assert executor.parse_errors == []
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportCheckout)
 
 Create commit on base to bring it ahead of the follower:
 

--- a/checkoutmanager/tests/dirinfo_svn.rst
+++ b/checkoutmanager/tests/dirinfo_svn.rst
@@ -122,9 +122,6 @@ Tests for the 'in' dirinfo action:
     >>> executor = runner.run_one('in', directory=svn_wc2, conf=conf)
     >>> assert isinstance(executor.reports, list)
     >>> assert len(executor.errors) == 0
-    >>> if len(executor.parse_errors):
-    ...     for error in executor.parse_errors:
-    ...         error.print_msg()
     >>> assert len(executor.parse_errors) == 0
     >>> assert len(executor.reports) == 1
     >>> assert isinstance(executor.reports[0], reports.ReportIncoming)
@@ -136,6 +133,23 @@ Tests for the 'in' dirinfo action:
 Tests for the 'up' dirinfo action. Update the working copy:
 
     >>> executor = runner.run_one('up', directory=svn_wc2, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.errors) == 0
+    >>> assert len(executor.parse_errors) == 0
+    >>> if len(executor.parse_errors):
+    ...     print(executor.parse_errors)
+    ...     for error in executor.parse_errors:
+    ...         error.print_msg()
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportUpdate)
+    >>> assert not executor.reports[0].initial_head
+    >>> assert executor.reports[0].final_head == 1
+    >>> assert len(executor.reports[0].changes) == 1
+    >>> change = executor.reports[0].changes[0]
+    >>> assert isinstance(change, reports.FileStatus)
+    >>> assert change.filepath == 'test_file'
+    >>> assert change.status == 'A   '
+    >>> assert not change.moreinfo
 
 Teardown:
 

--- a/checkoutmanager/tests/dirinfo_svn.rst
+++ b/checkoutmanager/tests/dirinfo_svn.rst
@@ -40,7 +40,7 @@ Create an SVN repository:
     >>> subprocess.call(cmd)
     0
 
-Create the working copies using checkoutmanager:
+Test the 'co' dirinfo action. Create the working copies using checkoutmanager:
 
     >>> svn_wc2 = os.path.join(svn_repos_root, 'wc2')
     >>> svn_wc1 = os.path.join(svn_repos_root, 'wc1')
@@ -60,15 +60,43 @@ Create the working copies using checkoutmanager:
     >>> assert len(executor.reports) == 1
     >>> assert isinstance(executor.reports[0], reports.ReportCheckout)
 
-Create a file inside the first working copy and commit:
+Test the 'st' dirinfo action. Create a file inside the first working copy and commit:
 
     >>> os.chdir(svn_wc1)
     >>> with open(os.path.join(svn_wc1, 'test_file'), 'w+') as f:
     ...     f.writelines('Foo')
+    >>> executor = runner.run_one('st', directory=svn_wc1, conf=conf)
+    >>> assert len(executor.errors) == 0
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> report = executor.reports[0]
+    >>> assert isinstance(report, reports.ReportStatus)
+    >>> assert len(report.changes) == 1
+    >>> change = report.changes[0]
+    >>> assert isinstance(change, reports.FileStatus)
+    >>> assert change.filepath == 'test_file'
+    >>> assert change.status == '?      '
+    >>> assert not change.moreinfo
     >>> cmd = ['svn', 'add', 'test_file']
     >>> subprocess.call(cmd)
+    >>> executor = runner.run_one('st', directory=svn_wc1, conf=conf)
+    >>> assert len(executor.errors) == 0
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> report = executor.reports[0]
+    >>> assert isinstance(report, reports.ReportStatus)
+    >>> assert len(report.changes) == 1
+    >>> change = report.changes[0]
+    >>> assert isinstance(change, reports.FileStatus)
+    >>> assert change.filepath == 'test_file'
+    >>> assert change.status == 'A      '
+    >>> assert not change.moreinfo
     >>> cmd = ['svn', 'ci', '-m', '\"one commit\"']
     >>> subprocess.call(cmd)
+    >>> executor = runner.run_one('st', directory=svn_wc1, conf=conf)
+    >>> assert len(executor.errors) == 0
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 0
     >>> # SVN needs an up before the revision changes in the source
     >>> # working copy.
     >>> cmd = ['svn', 'up']

--- a/checkoutmanager/tests/dirinfo_svn.rst
+++ b/checkoutmanager/tests/dirinfo_svn.rst
@@ -1,0 +1,88 @@
+
+.. :doctest:
+
+    >>> import subprocess
+    >>> import os
+    >>> from checkoutmanager.dirinfo import SvnDirInfo
+    >>> orig_cwd = os.getcwd()
+
+The tests will all run inside the homedir which the testsetup made for us:
+
+    >>> print(homedir)
+    HOMEDIR
+
+Create the config file:
+
+    >>> vcstest_config_path = os.path.join(homedir, 'vcstestconfig.cfg')
+    >>> import pkg_resources
+    >>> vcstest_config_tpath = pkg_resources.resource_filename(
+    ...     'checkoutmanager.tests', 'vcstestconfig.cfg.templ')
+    >>> with open(vcstest_config_tpath, 'r') as f:
+    ...     vcstest_config_tstr = str(f.read())
+    >>> import jinja2
+    >>> vcstest_config_t = jinja2.Template(vcstest_config_tstr)
+    >>> with open(vcstest_config_path, 'w') as f:
+    ...     lc = f.write(vcstest_config_t.render(homedir=homedir))
+    >>> from checkoutmanager import config
+    >>> conf = config.Config(vcstest_config_path)
+
+Make yourself a folder inside which all SVN tests will run:
+
+    >>> svn_repos_root = os.path.join(homedir, 'repos_svn')
+    >>> os.makedirs(svn_repos_root)
+    >>> print(svn_repos_root)
+    HOMEDIR/repos_svn
+
+Create an SVN repository:
+
+    >>> svn_upstream = os.path.join(svn_repos_root, 'a_repo')
+    >>> cmd = ['svnadmin', 'create', '--fs-type', 'fsfs', svn_upstream]
+    >>> subprocess.call(cmd)
+    0
+
+Create the working copies using checkoutmanager:
+
+    >>> svn_wc2 = os.path.join(svn_repos_root, 'wc2')
+    >>> svn_wc1 = os.path.join(svn_repos_root, 'wc1')
+    >>> from checkoutmanager import runner
+    >>> executor = runner.run_one('co', directory=svn_wc1, conf=conf)
+    >>> assert executor.errors == []
+    >>> executor = runner.run_one('co', directory=svn_wc2, conf=conf)
+    >>> assert executor.errors == []
+
+Create a file inside the first working copy and commit:
+
+    >>> os.chdir(svn_wc1)
+    >>> with open(os.path.join(svn_wc1, 'test_file'), 'w+') as f:
+    ...     f.writelines('Foo')
+    >>> cmd = ['svn', 'add', 'test_file']
+    >>> subprocess.call(cmd)
+    >>> cmd = ['svn', 'ci', '-m', '\"one commit\"']
+    >>> subprocess.call(cmd)
+    >>> # SVN needs an up before the revision changes in the source
+    >>> # working copy.
+    >>> cmd = ['svn', 'up']
+    >>> subprocess.call(cmd)
+
+Tests for the 'rev' dirinfo action:
+
+    >>> # TODO Reintroduce when merged with collectors branch
+    >>> # from checkoutmanager import reports
+    >>> executor = runner.run_one('rev', directory=svn_wc1, conf=conf)
+    >>> # assert isinstance(executor.reports, list)
+    >>> # assert len(executor.reports) == 1
+    >>> # assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> # assert executor.reports[0].revision == 1
+    >>> executor = runner.run_one('rev', directory=svn_wc2, conf=conf)
+    >>> # assert isinstance(executor.reports, list)
+    >>> # assert len(executor.reports) == 1
+    >>> # assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> # assert executor.reports[0].revision == 0
+    >>> # TODO handle error conditons
+
+Teardown:
+
+    >>> os.chdir(orig_cwd)
+
+
+

--- a/checkoutmanager/tests/dirinfo_svn.rst
+++ b/checkoutmanager/tests/dirinfo_svn.rst
@@ -45,10 +45,20 @@ Create the working copies using checkoutmanager:
     >>> svn_wc2 = os.path.join(svn_repos_root, 'wc2')
     >>> svn_wc1 = os.path.join(svn_repos_root, 'wc1')
     >>> from checkoutmanager import runner
+    >>> from checkoutmanager import reports
     >>> executor = runner.run_one('co', directory=svn_wc1, conf=conf)
     >>> assert executor.errors == []
+    >>> assert executor.parse_errors == []
+    >>> print(executor.parse_errors)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportCheckout)
     >>> executor = runner.run_one('co', directory=svn_wc2, conf=conf)
     >>> assert executor.errors == []
+    >>> assert executor.parse_errors == []
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportCheckout)
 
 Create a file inside the first working copy and commit:
 

--- a/checkoutmanager/tests/dirinfo_svn.rst
+++ b/checkoutmanager/tests/dirinfo_svn.rst
@@ -66,19 +66,35 @@ Create a file inside the first working copy and commit:
 
 Tests for the 'rev' dirinfo action:
 
-    >>> # TODO Reintroduce when merged with collectors branch
-    >>> # from checkoutmanager import reports
+    >>> from checkoutmanager import reports
     >>> executor = runner.run_one('rev', directory=svn_wc1, conf=conf)
-    >>> # assert isinstance(executor.reports, list)
-    >>> # assert len(executor.reports) == 1
-    >>> # assert isinstance(executor.reports[0], reports.ReportRevision)
-    >>> # assert executor.reports[0].revision == 1
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> assert executor.reports[0].revision == 1
     >>> executor = runner.run_one('rev', directory=svn_wc2, conf=conf)
-    >>> # assert isinstance(executor.reports, list)
-    >>> # assert len(executor.reports) == 1
-    >>> # assert isinstance(executor.reports[0], reports.ReportRevision)
-    >>> # assert executor.reports[0].revision == 0
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportRevision)
+    >>> assert executor.reports[0].revision == 0
     >>> # TODO handle error conditons
+
+Tests for the 'in' dirinfo action:
+
+    >>> executor = runner.run_one('in', directory=svn_wc2, conf=conf)
+    >>> assert isinstance(executor.reports, list)
+    >>> assert len(executor.errors) == 0
+    >>> if len(executor.parse_errors):
+    ...     for error in executor.parse_errors:
+    ...         error.print_msg()
+    >>> assert len(executor.parse_errors) == 0
+    >>> assert len(executor.reports) == 1
+    >>> assert isinstance(executor.reports[0], reports.ReportIncoming)
+    >>> assert executor.reports[0].local_head == 0
+    >>> assert executor.reports[0].remote_head == 1
+    >>> assert len(executor.reports[0].changesets) == 1
+    >>> assert executor.reports[0].changesets[0] == 1
+
 
 Teardown:
 

--- a/checkoutmanager/tests/dirinfo_svn.rst
+++ b/checkoutmanager/tests/dirinfo_svn.rst
@@ -133,6 +133,9 @@ Tests for the 'in' dirinfo action:
     >>> assert len(executor.reports[0].changesets) == 1
     >>> assert executor.reports[0].changesets[0] == 1
 
+Tests for the 'up' dirinfo action. Update the working copy:
+
+    >>> executor = runner.run_one('up', directory=svn_wc2, conf=conf)
 
 Teardown:
 

--- a/checkoutmanager/tests/vcstestconfig.cfg.templ
+++ b/checkoutmanager/tests/vcstestconfig.cfg.templ
@@ -1,0 +1,37 @@
+# Sample config file.  Should be placed as
+# .checkoutmanager.cfg in your home directory.
+#
+# Different sections per base location
+# and version control system.  Splitting everything all over
+# the place in multiple directories is fine.
+
+[svn]
+vcs = svn
+basedir = ~/repos_svn/
+checkouts =
+    file:///{{ homedir }}/repos_svn/a_repo  wc1
+    file:///{{ homedir }}/repos_svn/a_repo  wc2
+
+[git]
+vcs = git
+basedir = ~/repos_git/
+checkouts =
+    /{{ homedir }}/repos_git/base
+    /{{ homedir }}/repos_git/base  follower
+    /{{ homedir }}/repos_git/base  leader
+
+[bzr]
+vcs = bzr
+basedir = ~/repos_bzr/
+checkouts =
+    /{{ homedir }}/repos_bzr/base
+    /{{ homedir }}/repos_bzr/base  follower
+    /{{ homedir }}/repos_bzr/base  leader
+
+[hg]
+vcs = hg
+basedir = ~/repos_hg/
+checkouts =
+    /{{ homedir }}/repos_hg/base
+    /{{ homedir }}/repos_hg/base  follower
+    /{{ homedir }}/repos_hg/base  leader

--- a/checkoutmanager/tests/vcstestconfig.cfg.templ
+++ b/checkoutmanager/tests/vcstestconfig.cfg.templ
@@ -16,7 +16,7 @@ checkouts =
 vcs = git
 basedir = ~/repos_git/
 checkouts =
-    /{{ homedir }}/repos_git/base
+    /{{ homedir }}/repos_git/base  base
     /{{ homedir }}/repos_git/base  follower
     /{{ homedir }}/repos_git/base  leader
 
@@ -24,7 +24,7 @@ checkouts =
 vcs = bzr
 basedir = ~/repos_bzr/
 checkouts =
-    /{{ homedir }}/repos_bzr/base
+    /{{ homedir }}/repos_bzr/base  base
     /{{ homedir }}/repos_bzr/base  follower
     /{{ homedir }}/repos_bzr/base  leader
 
@@ -32,6 +32,6 @@ checkouts =
 vcs = hg
 basedir = ~/repos_hg/
 checkouts =
-    /{{ homedir }}/repos_hg/base
-    /{{ homedir }}/repos_hg/base  follower
-    /{{ homedir }}/repos_hg/base  leader
+    file://{{ homedir }}/repos_hg/base  base
+    file://{{ homedir }}/repos_hg/base  follower
+    file://{{ homedir }}/repos_hg/base  leader

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(name='checkoutmanager',
           'test': [
               'z3c.testsetup>=0.3',
               'zope.testing',
+              'jinja2',
               ],
           },
       entry_points={


### PR DESCRIPTION
This PR lays out a framework for parsing the output of the version control system output and returning parsed results to callers. This also allows for producing a summary of the actions at the end of a run.

Much of this code relies heavily on VCS outputs, and so may take some testing before it is ready to be used on a regular basis.

Different VCSs provide different pieces of information - this is most stark in the 'up' command. The report classes are intended to provide a unified interface to the information printed to stdout by the VCS. I suspect a great deal of tweaking of this interface (and the corresponding parsers) may be necessary based on user feedback and bug reports. As such, this code is written to be as resilient to errors as possible. Errors will be caught and not result in a report, but rest of the execution can go on. 

Presently, the default usage of checkoutmanager as a script makes use of none of this code, and should, in fact, never execute any of it. It is fairly simple to turn on this code once everyone's comfortable with it (and necessary, even, to fulfil the requirement of condensed output - which is what I started working on checkoutmanager to do). 
