### PR TITLE
More robust error-handling

### DIFF
--- a/checkoutmanager/executors.py
+++ b/checkoutmanager/executors.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8
 from __future__ import print_function
 from __future__ import unicode_literals
+
+import traceback
 from multiprocessing.pool import Pool
 import time
 
@@ -35,6 +37,17 @@ class _Executor(object):
             return
         print(result)
 
+    def _error(self, exception):
+        self.errors.append(exception)
+        if isinstance(exception, utils.CommandError):
+            result = exception.format_msg()
+        else:
+            result = "".join(traceback.format_exception_only(type(exception), exception))
+        if not result:
+            # Don't print empty lines
+            return
+        print(result)
+
     def execute(self, func, args):
         """Execute the given function"""
         raise NotImplementedError("Sub-classes must implement this")
@@ -47,23 +60,21 @@ class _Executor(object):
 class _SingleExecutor(_Executor):
     """Execute functions in the same thread and process (sync)"""
     def execute(self, func, args):
-        self._collector(func(*args))
+        try:
+            self._collector(func(*args))
+        except Exception as e:
+            self._error(e)
 
 
 class _MultiExecutor(_Executor):
     """Execute functions async in a process pool"""
     def __init__(self):
         super(_MultiExecutor, self).__init__()
-        self._children = 0
+        self._async_results = []
         self.pool = Pool()
 
-    def _collector(self, result):
-        super(_MultiExecutor, self)._collector(result)
-        self._children -= 1
-
     def execute(self, func, args):
-        self._children += 1
-        self.pool.apply_async(func, args, callback=self._collector)
+        self._async_results.append(self.pool.apply_async(func, args, callback=self._collector, error_callback=self._error))
 
     def wait_for_results(self):
         self.pool.close()
@@ -71,6 +82,6 @@ class _MultiExecutor(_Executor):
         # apparently you need to first make sure that all your launched tasks
         # has returned their results properly, before calling join, or you
         # risk a deadlock.
-        while self._children > 0:
+        while any(not r.ready() for r in self._async_results):
             time.sleep(0.001)
         self.pool.join()

--- a/checkoutmanager/executors.py
+++ b/checkoutmanager/executors.py
@@ -3,7 +3,6 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import traceback
 from multiprocessing.pool import Pool
 import time
 
@@ -39,14 +38,7 @@ class _Executor(object):
 
     def _error(self, exception):
         self.errors.append(exception)
-        if isinstance(exception, utils.CommandError):
-            result = exception.format_msg()
-        else:
-            result = "".join(traceback.format_exception_only(type(exception), exception))
-        if not result:
-            # Don't print empty lines
-            return
-        print(result)
+        utils.print_exception(exception)
 
     def execute(self, func, args):
         """Execute the given function"""

--- a/checkoutmanager/runner.py
+++ b/checkoutmanager/runner.py
@@ -194,5 +194,5 @@ def main():
         print("### %s ERRORS OCCURED ###" % len(executor.errors))
         for error in executor.errors:
             print()
-            print(error.format_msg())
+            utils.print_exception(error)
         sys.exit(1)

--- a/checkoutmanager/utils.py
+++ b/checkoutmanager/utils.py
@@ -5,6 +5,7 @@ from functools import wraps
 import os
 import subprocess
 import sys
+import traceback
 
 # For zc.buildout's system() method:
 MUST_CLOSE_FDS = not sys.platform.startswith('win')
@@ -77,3 +78,13 @@ def capture_stdout(func):
         finally:
             sys.stdout = sys.__stdout__
     return newfunc
+
+
+def print_exception(exception):
+    if isinstance(exception, CommandError):
+        result = exception.format_msg()
+    else:
+        result = "".join(traceback.format_exception_only(type(exception), exception))
+    # Don't print empty lines
+    if result:
+        print(result)


### PR DESCRIPTION
Especially in parallel mode, some errors tend to make checkoutmanager hang instead of erroring out. This is probably because of a naive approach to tracking worker completion. I've tried using a smarter approach, and also added a bit more explicit error handling. I might have missed something about the `CommandError` exception, so make sure to check that what I've done makes sense.

I've tried figuring out how to run the tests, but came up short, so I don't know if any tests break with this change.